### PR TITLE
example(angular-ngc): remove unused ng_pkg(data)

### DIFF
--- a/angular-ngc/defs.bzl
+++ b/angular-ngc/defs.bzl
@@ -220,7 +220,7 @@ def _pkg_web(name, entry_point, entry_deps, html_assets, assets, production, vis
         visibility = visibility,
     )
 
-def ng_pkg(name, deps = [], data = [], test_deps = [], visibility = ["//visibility:public"]):
+def ng_pkg(name, deps = [], test_deps = [], visibility = ["//visibility:public"]):
     """
     Bazel macro for compiling an npm-like Angular package project. Creates '{name}' and 'test' targets.
 
@@ -235,8 +235,7 @@ def ng_pkg(name, deps = [], data = [], test_deps = [], visibility = ["//visibili
 
     Args:
       name: the rule name
-      deps: compilation dependencies
-      data: runtime dependencies
+      deps: package dependencies
       test_deps: additional dependencies for tests
       visibility: visibility of the primary targets ('{name}', 'test')
     """

--- a/angular-ngc/packages/lib-a/BUILD.bazel
+++ b/angular-ngc/packages/lib-a/BUILD.bazel
@@ -7,9 +7,6 @@ npm_link_all_packages(name = "node_modules")
 
 ng_pkg(
     name = "lib-a",
-    data = [
-        ":node_modules/@ngc-example/common",
-    ],
     deps = [
         ":node_modules/@ngc-example/common",
         "//packages/lib-a/src/lib/strings",


### PR DESCRIPTION
I realized this isn't even used. I probably did it while trying to debug those npm link issues...