### PR TITLE
Add incompatible_allow_tags_propagation to fetch and query

### DIFF
--- a/bazelrc/.bazelrc
+++ b/bazelrc/.bazelrc
@@ -29,6 +29,8 @@ build --nolegacy_external_runfiles
 build --incompatible_remote_results_ignore_disk
 build --incompatible_default_to_explicit_init_py
 build --incompatible_allow_tags_propagation
+fetch --incompatible_allow_tags_propagation
+query --incompatible_allow_tags_propagation
 
 ###
 # Convenience


### PR DESCRIPTION
When adding `--incompatible_allow_tags_propagation`, it should be added for fetch and query too. Otherwise users of `query`-based tooling like `ibazel` or the `gopackagesdriver` of `rules_go` invalidate their analysis graphs whenever those tools run.