### PR TITLE
Use `out_dirs` for `next` macro output

### DIFF
--- a/next.js/bazel/next.bzl
+++ b/next.js/bazel/next.bzl
@@ -128,7 +128,7 @@ def next(
         tool = next_js_binary,
         args = ["build"],
         srcs = srcs + data,
-        outs = [next_build_out],
+        out_dirs = [next_build_out],
         chdir = native.package_name(),
         **kwargs
     )


### PR DESCRIPTION
We were seeing readonly filesystem errors on Linux when using a single file `out`. This outputs a directory and `out_dirs` produces the correct behavior.