### PR TITLE
chore: update to rules_js 1.15.0

### DIFF
--- a/angular-ngc/WORKSPACE.bazel
+++ b/angular-ngc/WORKSPACE.bazel
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "c4a5766a45dff25b2eb1789d7a2decfda81b281fc88350d24687620c37fefb25",
-    strip_prefix = "rules_js-1.14.0",
-    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.14.0.tar.gz",
+    sha256 = "ddb66aad3c5bc288222a4260525b6d9e0c847b12fcc28177c91c21ef05080c43",
+    strip_prefix = "rules_js-1.15.0",
+    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.15.0.tar.gz",
 )
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")

--- a/angular/WORKSPACE.bazel
+++ b/angular/WORKSPACE.bazel
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "c4a5766a45dff25b2eb1789d7a2decfda81b281fc88350d24687620c37fefb25",
-    strip_prefix = "rules_js-1.14.0",
-    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.14.0.tar.gz",
+    sha256 = "ddb66aad3c5bc288222a4260525b6d9e0c847b12fcc28177c91c21ef05080c43",
+    strip_prefix = "rules_js-1.15.0",
+    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.15.0.tar.gz",
 )
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")

--- a/directory_path/WORKSPACE
+++ b/directory_path/WORKSPACE
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "c4a5766a45dff25b2eb1789d7a2decfda81b281fc88350d24687620c37fefb25",
-    strip_prefix = "rules_js-1.14.0",
-    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.14.0.tar.gz",
+    sha256 = "ddb66aad3c5bc288222a4260525b6d9e0c847b12fcc28177c91c21ef05080c43",
+    strip_prefix = "rules_js-1.15.0",
+    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.15.0.tar.gz",
 )
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")

--- a/jest/WORKSPACE
+++ b/jest/WORKSPACE
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "c4a5766a45dff25b2eb1789d7a2decfda81b281fc88350d24687620c37fefb25",
-    strip_prefix = "rules_js-1.14.0",
-    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.14.0.tar.gz",
+    sha256 = "ddb66aad3c5bc288222a4260525b6d9e0c847b12fcc28177c91c21ef05080c43",
+    strip_prefix = "rules_js-1.15.0",
+    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.15.0.tar.gz",
 )
 
 http_archive(

--- a/nestjs/WORKSPACE
+++ b/nestjs/WORKSPACE
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "c4a5766a45dff25b2eb1789d7a2decfda81b281fc88350d24687620c37fefb25",
-    strip_prefix = "rules_js-1.14.0",
-    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.14.0.tar.gz",
+    sha256 = "ddb66aad3c5bc288222a4260525b6d9e0c847b12fcc28177c91c21ef05080c43",
+    strip_prefix = "rules_js-1.15.0",
+    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.15.0.tar.gz",
 )
 
 http_archive(

--- a/next.js/WORKSPACE.bazel
+++ b/next.js/WORKSPACE.bazel
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "c4a5766a45dff25b2eb1789d7a2decfda81b281fc88350d24687620c37fefb25",
-    strip_prefix = "rules_js-1.14.0",
-    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.14.0.tar.gz",
+    sha256 = "ddb66aad3c5bc288222a4260525b6d9e0c847b12fcc28177c91c21ef05080c43",
+    strip_prefix = "rules_js-1.15.0",
+    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.15.0.tar.gz",
 )
 
 http_archive(

--- a/pnpm-workspaces/WORKSPACE.bazel
+++ b/pnpm-workspaces/WORKSPACE.bazel
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "c4a5766a45dff25b2eb1789d7a2decfda81b281fc88350d24687620c37fefb25",
-    strip_prefix = "rules_js-1.14.0",
-    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.14.0.tar.gz",
+    sha256 = "ddb66aad3c5bc288222a4260525b6d9e0c847b12fcc28177c91c21ef05080c43",
+    strip_prefix = "rules_js-1.15.0",
+    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.15.0.tar.gz",
 )
 
 http_archive(

--- a/protobufjs/WORKSPACE.bazel
+++ b/protobufjs/WORKSPACE.bazel
@@ -5,9 +5,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 ###
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "c4a5766a45dff25b2eb1789d7a2decfda81b281fc88350d24687620c37fefb25",
-    strip_prefix = "rules_js-1.14.0",
-    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.14.0.tar.gz",
+    sha256 = "ddb66aad3c5bc288222a4260525b6d9e0c847b12fcc28177c91c21ef05080c43",
+    strip_prefix = "rules_js-1.15.0",
+    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.15.0.tar.gz",
 )
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")

--- a/react-cra/WORKSPACE
+++ b/react-cra/WORKSPACE
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "c4a5766a45dff25b2eb1789d7a2decfda81b281fc88350d24687620c37fefb25",
-    strip_prefix = "rules_js-1.14.0",
-    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.14.0.tar.gz",
+    sha256 = "ddb66aad3c5bc288222a4260525b6d9e0c847b12fcc28177c91c21ef05080c43",
+    strip_prefix = "rules_js-1.15.0",
+    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.15.0.tar.gz",
 )
 
 http_archive(

--- a/rules_nodejs_to_rules_js_migration/WORKSPACE
+++ b/rules_nodejs_to_rules_js_migration/WORKSPACE
@@ -6,9 +6,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "c4a5766a45dff25b2eb1789d7a2decfda81b281fc88350d24687620c37fefb25",
-    strip_prefix = "rules_js-1.14.0",
-    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.14.0.tar.gz",
+    sha256 = "ddb66aad3c5bc288222a4260525b6d9e0c847b12fcc28177c91c21ef05080c43",
+    strip_prefix = "rules_js-1.15.0",
+    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.15.0.tar.gz",
 )
 
 http_archive(

--- a/ts_project_transpiler/WORKSPACE
+++ b/ts_project_transpiler/WORKSPACE
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "c4a5766a45dff25b2eb1789d7a2decfda81b281fc88350d24687620c37fefb25",
-    strip_prefix = "rules_js-1.14.0",
-    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.14.0.tar.gz",
+    sha256 = "ddb66aad3c5bc288222a4260525b6d9e0c847b12fcc28177c91c21ef05080c43",
+    strip_prefix = "rules_js-1.15.0",
+    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.15.0.tar.gz",
 )
 
 http_archive(

--- a/vue/WORKSPACE.bazel
+++ b/vue/WORKSPACE.bazel
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "aspect_rules_js",
-    sha256 = "c4a5766a45dff25b2eb1789d7a2decfda81b281fc88350d24687620c37fefb25",
-    strip_prefix = "rules_js-1.14.0",
-    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.14.0.tar.gz",
+    sha256 = "ddb66aad3c5bc288222a4260525b6d9e0c847b12fcc28177c91c21ef05080c43",
+    strip_prefix = "rules_js-1.15.0",
+    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.15.0.tar.gz",
 )
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")

--- a/write_source_files/WORKSPACE
+++ b/write_source_files/WORKSPACE
@@ -27,9 +27,9 @@ http_archive(
 
 http_archive(
     name = "aspect_bazel_lib",
-    sha256 = "558d70e36425c317c70b19fb0f68241a3747bcf46561b5ffc19bed17527adbb3",
-    strip_prefix = "bazel-lib-1.20.0",
-    url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.20.0.tar.gz",
+    sha256 = "79623d656aa23ad3fd4692ab99786c613cd36e49f5566469ed97bc9b4c655f03",
+    strip_prefix = "bazel-lib-1.23.3",
+    url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.23.3.tar.gz",
 )
 
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")


### PR DESCRIPTION
Will bump bzlmod example in a follow-up after https://github.com/bazelbuild/bazel-central-registry/pull/376 lands