### PR TITLE
fix: duplicate includes of Vue

### DIFF
--- a/vue/vite.config.ts
+++ b/vue/vite.config.ts
@@ -11,6 +11,6 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
-    dedupe: ["vue"]
+    dedupe: ['vue'],
   },
 });

--- a/vue/vite.config.ts
+++ b/vue/vite.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
+    dedupe: ["vue"]
   },
 });


### PR DESCRIPTION
It seems like `@yourname/yourlibrary` has its own copy of vue in its `node_modules` and as a result Vite is including both in the bundle. The fix here instructs Vite to de-duplicate the library. There may be other approaches to fixing this such as having the library reference a version of vue defined at the workspace level, but the solution in this PR is also fairly conventional.

resolves: https://github.com/aspect-build/bazel-examples/issues/66