### PR TITLE
example(next.js): fix docs label for next_js_binary location

### DIFF
--- a/next.js/bazel/next.bzl
+++ b/next.js/bazel/next.bzl
@@ -39,7 +39,7 @@ def next(
             "package.json",
         ],
         next_bin = "../../node_modules/.bin/next",
-        next_js_binary = ":next_js_binary",
+        next_js_binary = "//:next_js_binary",
     )
     ```
 


### PR DESCRIPTION
The `/apps/alpha` package does not contain `next_js_binary` for this example.