### PR TITLE
fix: transition oci_image instead of pkg_tar only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+bazel-*

--- a/oci_go_image/BUILD.bazel
+++ b/oci_go_image/BUILD.bazel
@@ -17,18 +17,12 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
+# Put app go_binary into a tar layer.
 pkg_tar(
-    name = "tar",
+    name = "app_layer",
     srcs = [":app"],
-)
-
-platform_transition_filegroup(
-    name = "transition",
-    srcs = [":tar"],
-    target_platform = select({
-        "@platforms//cpu:arm64": "@rules_go//go/toolchain:linux_arm64",
-        "@platforms//cpu:x86_64": "@rules_go//go/toolchain:linux_amd64",
-    }),
+    # If the binary depends on RUNFILES, uncomment the attribute below.
+    # include_runfiles = True
 )
 
 oci_image(
@@ -40,7 +34,16 @@ oci_image(
     base = "@distroless_base",
     entrypoint = ["/app"],
     os = "linux",
-    tars = [":transition"],
+    tars = [":app_layer"],
+)
+
+platform_transition_filegroup(
+    name = "transitioned_image",
+    srcs = [":image"],
+    target_platform = select({
+        "@platforms//cpu:arm64": "@rules_go//go/toolchain:linux_arm64",
+        "@platforms//cpu:x86_64": "@rules_go//go/toolchain:linux_amd64",
+    }),
 )
 
 # $ bazel build app:tarball
@@ -52,12 +55,12 @@ oci_image(
 #   )
 oci_tarball(
     name = "tarball",
-    image = ":image",
+    image = ":transitioned_image",
     repotags = ["gcr.io/example:latest"],
 )
 
 structure_test(
     name = "test",
     config = ["test.yaml"],
-    image = ":image",
+    image = ":transitioned_image",
 )


### PR DESCRIPTION
# Description

Before these changes, only pkg_tar was transitioned which led to an incorrect base image being chosen independently from the arch of the binary. 

Fixes # (issue)

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature or functionality (change which adds functionality)
- [ ] Style (white-space, formatting, etc...)
- [ ] Refactor (a code change that neither fixes a bug or adds a new feature)
- [ ] Performance (a code change that improves performance)
- [ ] Documentation (updates to documentation or READMEs)
- [ ] Chore (any other change that doesn't affect source or test files)

# Properties of change

- [ ] Breaking change (this change will cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Test plan

How has this been tested?

- [x] Covered by existing tests cases
- [ ] New test cases added
- [ ] Manual testing

If part of the test plan included manual testing, please provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
