### PR TITLE
fix: fix build-only script in vue example

### DIFF
--- a/vue/package.json
+++ b/vue/package.json
@@ -5,7 +5,7 @@
     "dev": "ibazel run :vite",
     "build": "run-p type-check build-only",
     "preview": "vite preview --port 4173",
-    "build-only": "bazel build :dist",
+    "build-only": "bazel build :build",
     "type-check": "bazel test :type-check"
   },
   "dependencies": {


### PR DESCRIPTION
`//:dist` is not a valid label since that output is a tree artifact which is not pre-declared.

**Type of change**

- [x] Bug fix (change which fixes an issue)

**Test plan**

- [x] Manual testing

Ran the build script