### PR TITLE
fix: disable ts_project workers //src:src_test_ts target in react-cra example to fix issue on macos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,10 +73,6 @@ jobs:
           - 'ts_project_transpiler'
           - 'vue'
           - 'write_source_files'
-        exclude:
-          # TODO: fixup: ERROR: react-cra/src/BUILD.bazel:50:11: output 'src/App.test.js' was not created
-          - os: macos-latest
-            folder: react-cra
 
     steps:
       - uses: actions/checkout@v3

--- a/react-cra/src/BUILD.bazel
+++ b/react-cra/src/BUILD.bazel
@@ -52,6 +52,7 @@ ts_project(
     srcs = glob(TEST_PATTERNS),
     declaration = True,
     resolve_json_module = True,
+    supports_workers = False,  # worker bug on macos: ERROR: react-cra/src/BUILD.bazel:50:11: output 'src/App.test.js' was not created
     tsconfig = "//:tsconfig",
     deps = [
         ":src_ts",


### PR DESCRIPTION
Works-around a ts_project worker issue that only manifests on macos.

---

### Type of change

- Bug fix (change which fixes an issue)
