### PR TITLE
refactor: clarify what's a workaround for rules_pkg

### DIFF
--- a/oci_python_image/hack/README.md
+++ b/oci_python_image/hack/README.md
@@ -1,4 +1,0 @@
-# Hack
-
-This folder contains Bazel modules to support missing features in rules_pkg, more specifically pkg_tar. These should be
-used with caution while a proper fix in pkg_tar doesn't exist.

--- a/oci_python_image/hello_world/BUILD.bazel
+++ b/oci_python_image/hello_world/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
-load("//hack:runfiles.bzl", "py_image_layer")
+load("//:py_image_layer.bzl", "py_image_layer")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 py_library(

--- a/oci_python_image/py_image_layer.bzl
+++ b/oci_python_image/py_image_layer.bzl
@@ -1,0 +1,61 @@
+"Simple macro to create tar files from a Python binary."
+
+load("//workaround_rules_pkg_153:runfiles.bzl", "runfiles")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+def py_image_layer(name, binary, root = None, **kwargs):
+    """Creates a tar file to add to a python image, output at `:<name>/app.tar`.
+
+    The final directory tree will look like the following:
+
+    `/{root of py_image_layer}/{package_name() if any}/{name of py_binary}.sh` -> entrypoint
+    `/{root of py_image_layer}/{package_name() if any}/{name of py_binary}.sh.runfiles` -> runfiles directory (almost identical to one bazel lays out)
+
+    Args:
+        name: name for this target. Not reflected anywhere in the final tar.
+        binary: label of a py_binary target
+        root: Path where the py_binary will reside inside the final container image.
+        **kwargs: Passed to pkg_tar. See: https://github.com/bazelbuild/rules_pkg/blob/main/docs/0.7.0/reference.md#pkg_tar
+    """
+    if root != None and not root.startswith("/"):
+        fail("root path must start with '/' but got '{root}', expected '/{root}'".format(root = root))
+
+    if kwargs.pop("package_dir", None):
+        fail("use 'root' attribute instead of 'package_dir'.")
+
+    common_kwargs = {
+        "tags": kwargs.pop("tags", None),
+        "visibility": kwargs.pop("visibility", None),
+    }
+
+    runfiles_kwargs = dict(
+        common_kwargs,
+        binary = binary,
+        root = root,
+    )
+
+    pkg_tar_kwargs = dict(
+        kwargs,
+        # Be careful with this option. Leave it as is if you don't know what you are doing
+        strip_prefix = kwargs.pop("strip_prefix", "."),
+        **common_kwargs
+    )
+
+    runfiles(
+        name = "%s/app/runfiles" % name,
+        **runfiles_kwargs
+    )
+
+    pkg_tar(
+        name = "%s/app" % name,
+        srcs = ["%s/app/runfiles" % name],
+        **pkg_tar_kwargs
+    )
+
+    native.filegroup(
+        name = name,
+        srcs = [
+            "%s/app" % name,
+        ],
+        **common_kwargs
+    )

--- a/oci_python_image/workaround_rules_pkg_153/BUILD.bazel
+++ b/oci_python_image/workaround_rules_pkg_153/BUILD.bazel
@@ -1,0 +1,4 @@
+"""
+This folder contains Bazel modules to support missing features in rules_pkg, more specifically pkg_tar.
+These should be used with caution while a proper fix in pkg_tar doesn't exist.
+"""


### PR DESCRIPTION
The stuff we would keep after rules_pkg#153 is fixed is now split out to a starlark module in the root folder.

---

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

### Test plan

- Covered by existing test cases
