### PR TITLE
Fix typo in oci_go_image example

### DIFF
--- a/oci_go_image/BUILD.bazel
+++ b/oci_go_image/BUILD.bazel
@@ -58,7 +58,7 @@ oci_tarball(
     name = "tarball",
     # Use the image built for the exec platform rather than the target platform
     image = ":image",
-    repotags = ["gcr.io/example:latest"],
+    repo_tags = ["gcr.io/example:latest"],
 )
 
 structure_test(


### PR DESCRIPTION
---

### Type of change
- Documentation (updates to documentation or READMEs)

Encountered when following the example: `no such attribute 'repotags' in 'oci_tarball' rule (did you mean 'repo_tags'?)`
