### PR TITLE
Update oci_go_image example

### DIFF
--- a/oci_go_image/BUILD.bazel
+++ b/oci_go_image/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball", "structure_test")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 go_library(
@@ -27,13 +28,8 @@ pkg_tar(
 
 oci_image(
     name = "image",
-    architecture = select({
-        "@platforms//cpu:arm64": "arm64",
-        "@platforms//cpu:x86_64": "amd64",
-    }),
     base = "@distroless_base",
     entrypoint = ["/app"],
-    os = "linux",
     tars = [":app_layer"],
 )
 
@@ -47,8 +43,8 @@ platform_transition_filegroup(
     }),
 )
 
-# $ bazel build app:tarball
-# $ docker load --input $(bazel cquery --output=files app:tarball)
+# $ bazel build :tarball
+# $ docker load --input $(bazel cquery --output=files :tarball)
 # $ docker run --rm gcr.io/example:latest
 #   string(
 # -       "Hello World",
@@ -58,12 +54,12 @@ oci_tarball(
     name = "tarball",
     # Use the image built for the exec platform rather than the target platform
     image = ":image",
-    repotags = ["gcr.io/example:latest"],
+    repo_tags = ["gcr.io/example:latest"],
 )
 
-structure_test(
+container_structure_test(
     name = "test",
-    config = ["test.yaml"],
+    configs = ["test.yaml"],
     # Use the image built for the exec platform rather than the target platform
     image = ":image",
 )

--- a/oci_go_image/MODULE.bazel
+++ b/oci_go_image/MODULE.bazel
@@ -1,9 +1,10 @@
 bazel_dep(name = "aspect_bazel_lib", version = "1.31.1")
-bazel_dep(name = "gazelle", version = "0.29.0")
+bazel_dep(name = "container_structure_test", version = "1.15.0")
+bazel_dep(name = "gazelle", version = "0.31.0")
 bazel_dep(name = "platforms", version = "0.0.5")
-bazel_dep(name = "rules_oci", version = "0.3.8")
+bazel_dep(name = "rules_oci", version = "1.0.0")
 bazel_dep(name = "rules_pkg", version = "0.8.1")
-bazel_dep(name = "rules_go", version = "0.38.1")
+bazel_dep(name = "rules_go", version = "0.39.1")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 


### PR DESCRIPTION
Updates the `oci_go_image` example to use the latest version of `rules_oci` and other dependencies. 

```
jparraga@U-1DJORH1PD9VGC:~/code/bazel-examples/oci_go_image$ bazel build ...
DEBUG: gazelle@0.27.0/MODULE.bazel:7:6: WARNING: The bazel_gazelle Bazel module is still highly experimental and subject to change at any time. Only use it to try out bzlmod for now.
DEBUG: rules_go@0.37.0/MODULE.bazel:8:6: WARNING: The rules_go Bazel module is still highly experimental and subject to change at any time. Only use it to try out bzlmod for now.
DEBUG: rules_go@0.33.0/MODULE.bazel:7:6: WARNING: The rules_go Bazel module is still highly experimental and subject to change at any time. Only use it to try out bzlmod for now.
INFO: Analyzed 7 targets (110 packages loaded, 11672 targets configured).
INFO: Found 7 targets...
INFO: Elapsed time: 52.140s, Critical Path: 22.51s
INFO: 67 processes: 38 internal, 25 linux-sandbox, 4 local.
INFO: Build completed successfully, 67 total actions
```

---
### Type of change
- Refactor (a code change that neither fixes a bug or adds a new feature)

### Test plan

- Covered by existing test cases
