### PR TITLE
fix(oci_python): we misnamed our repo distroless_python 

### DIFF
--- a/oci_python_image/MODULE.bazel
+++ b/oci_python_image/MODULE.bazel
@@ -4,7 +4,7 @@ bazel_dep(name = "aspect_bazel_lib", version = "1.31.2")
 bazel_dep(name = "container_structure_test", version = "1.15.0")
 bazel_dep(name = "rules_pkg", version = "0.9.1")
 bazel_dep(name = "rules_python", version = "0.21.0")
-bazel_dep(name = "rules_oci", version = "1.2.0")
+bazel_dep(name = "rules_oci", version = "1.3.1")
 bazel_dep(name = "platforms", version = "0.0.6")
 
 python = use_extension("@rules_python//python:extensions.bzl", "python")
@@ -23,8 +23,10 @@ oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 
 oci.pull(
     name = "distroless_python",
-    digest = "sha256:b48e216f7c4adcf24fecd7016f3b8ead76866a19571819f67f47c1ccaf899717",
-    image = "python",
+    # tag = "latest", # as of 30 August 2023
+    digest = "sha256:5148968d8ae02a0f6d12efaca7a16e711ab43a4695a285e22dbbae70d6048937",
+    platforms = ["linux/amd64", "linux/arm64/v8"],
+    image = "gcr.io/distroless/python3",
 )
 
 use_repo(oci, "distroless_python")

--- a/oci_python_image/hello_world/BUILD.bazel
+++ b/oci_python_image/hello_world/BUILD.bazel
@@ -32,7 +32,7 @@ py_image_layer(
 oci_image(
     name = "image",
     base = "@distroless_python",
-    entrypoint = ["/opt/hello_world/hello_world_bin"],
+    cmd = ["/opt/hello_world/hello_world_bin"],
     tars = [":hello_world_layer"],
 )
 
@@ -61,8 +61,7 @@ platform_transition_filegroup(
     }),
 )
 
-# $ bazel build //hello_world:tarball
-# $ docker load --input $(bazel cquery --output=files //hello_world:tarball)
+# $ bazel run //hello_world:tarball
 # $ docker run --rm gcr.io/oci_python_hello_world:latest
 oci_tarball(
     name = "tarball",


### PR DESCRIPTION
but actually used index.docker.io/library/python

Fix it to really use distroless like we claimed
