### PR TITLE
fix: [Vue warn]: Invalid VNode type

### DIFF
--- a/vue/libraries/simple/vite.config.ts
+++ b/vue/libraries/simple/vite.config.ts
@@ -1,7 +1,7 @@
 const path = require('path');
 const { defineConfig } = require('vite');
 import vue from '@vitejs/plugin-vue';
-console.error('loaded');
+
 module.exports = defineConfig({
   plugins: [vue()], // to process SFC
   build: {
@@ -12,6 +12,7 @@ module.exports = defineConfig({
       fileName: (format) => `index.${format}.js`,
     },
     rollupOptions: {
+      external: ['vue'],
       output: {
         // disable warning on src/index.ts using both default and named export
         exports: 'named',


### PR DESCRIPTION
The Vite config for the library was including Vite in the bundle. This PR removes Vite from the library's bundle which results in a fix for the exported component. 

**Before**

```console
runtime-core.esm-bundler.js:40 [Vue warn]: Invalid VNode type: Symbol(Fragment) (symbol) 
  at <InputText> 
  at <App>
```
<img width="611" alt="Screenshot 2023-09-09 at 3 54 12 PM" src="https://github.com/aspect-build/bazel-examples/assets/20763171/0b01ecdc-f079-4f6c-b797-5f4342f5d043">

**After**
<img width="610" alt="Screenshot 2023-09-09 at 3 51 30 PM" src="https://github.com/aspect-build/bazel-examples/assets/20763171/3b215969-eeba-4a8a-80eb-9bc46df16eb1">

---
### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:

`bazel run :vite`
