### PR TITLE
Fix import for star wars quotes in rules_js example

### DIFF
--- a/pnpm-workspaces/apps/alpha/src/main.ts
+++ b/pnpm-workspaces/apps/alpha/src/main.ts
@@ -1,7 +1,7 @@
 import { one } from '@bazel-poc/one';
 import { shared } from '@bazel-poc/shared';
 import { getRandomQuote } from 'inspirational-quotes';
-import quotes from 'star-wars-quotes';
+import * as quotes from 'star-wars-quotes';
 
 shared();
 one();


### PR DESCRIPTION
---

### Type of change

- Bug fix (change which fixes an issue)

Failed with 
```console.log((0, _starwarsquotes.default)());
                                        ^

TypeError: (0 , _starwarsquotes.default) is not a function
```

**For changes visible to end-users**

- Suggested release notes are provided below:
rules_js pnpm examples now runs without fail

### Test plan

- Manual testing; please provide instructions so we can reproduce:
```cd pnpm-workspaces && bazel run //apps/alpha:main```