### PR TITLE
build: update pnpm-workspaces example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bazel-*
 node_modules
 .venv
+MODULE.bazel.lock

--- a/pnpm-workspaces/.aspect/bazelrc/bazel6.bazelrc
+++ b/pnpm-workspaces/.aspect/bazelrc/bazel6.bazelrc
@@ -13,3 +13,15 @@ build --reuse_sandbox_directories
 # Avoid this flag being enabled by remote_download_minimal or remote_download_toplevel
 # See https://meroton.com/blog/bazel-6-errors-build-without-the-bytes/
 build --noexperimental_action_cache_store_output_metadata
+
+# Speed up all builds by not checking if output files have been modified. Lets you make changes to
+# the output tree without triggering a build for local debugging. For example, you can modify
+# [rules_js](https://github.com/aspect-build/rules_js) 3rd party npm packages in the output tree
+# when local debugging.
+# Docs: https://github.com/bazelbuild/bazel/blob/1af61b21df99edc2fc66939cdf14449c2661f873/src/main/java/com/google/devtools/build/lib/pkgcache/PackageOptions.java#L185
+# NB: This flag is in bazel6.bazelrc as when used in Bazel 7 is has been observed to break
+# "build without the bytes" --remote_download_outputs=toplevel. See https://github.com/bazel-contrib/bazel-lib/pull/711
+# for more info.
+build --noexperimental_check_output_files
+fetch --noexperimental_check_output_files
+query --noexperimental_check_output_files

--- a/pnpm-workspaces/.aspect/bazelrc/convenience.bazelrc
+++ b/pnpm-workspaces/.aspect/bazelrc/convenience.bazelrc
@@ -3,7 +3,7 @@
 build --keep_going
 
 # Output test errors to stderr so users don't have to `cat` or open test failure log files when test
-# fail. This makes the log noiser in exchange for reducing the time-to-feedback on test failures for
+# fail. This makes the log noisier in exchange for reducing the time-to-feedback on test failures for
 # users.
 # Docs: https://bazel.build/docs/user-manual#test-output
 test --test_output=errors

--- a/pnpm-workspaces/.aspect/bazelrc/correctness.bazelrc
+++ b/pnpm-workspaces/.aspect/bazelrc/correctness.bazelrc
@@ -24,7 +24,7 @@ test --test_verbose_timeout_warnings
 # Allow the Bazel server to check directory sources for changes. Ensures that the Bazel server
 # notices when a directory changes, if you have a directory listed in the srcs of some target.
 # Recommended when using
-# [copy_directory](https://github.com/aspect-build/bazel-lib/blob/main/docs/copy_directory.md) and
+# [copy_directory](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/copy_directory.md) and
 # [rules_js](https://github.com/aspect-build/rules_js) since npm package are source directories
 # inputs to copy_directory actions.
 # Docs: https://bazel.build/reference/command-line-reference#flag--host_jvm_args
@@ -60,3 +60,16 @@ query --experimental_allow_tags_propagation
 # https://github.com/bazelbuild/bazel/issues/10076.
 # Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_default_to_explicit_init_py
 build --incompatible_default_to_explicit_init_py
+
+# Set default value of `allow_empty` to `False` in `glob()`. This prevents a common mistake when
+# attempting to use `glob()` to match files in a subdirectory that is opaque to the current package
+# because it contains a BUILD file. See https://github.com/bazelbuild/bazel/issues/8195.
+# Docs: https://bazel.build/reference/command-line-reference#flag--incompatible_disallow_empty_glob
+common --incompatible_disallow_empty_glob
+
+# Always download coverage files for tests from the remote cache. By default, coverage files are not
+# downloaded on test result cache hits when --remote_download_minimal is enabled, making it impossible
+# to generate a full coverage report.
+# Docs: https://bazel.build/reference/command-line-reference#flag--experimental_fetch_all_coverage_outputs
+# detching remote cache results
+test --experimental_fetch_all_coverage_outputs

--- a/pnpm-workspaces/.aspect/bazelrc/javascript.bazelrc
+++ b/pnpm-workspaces/.aspect/bazelrc/javascript.bazelrc
@@ -8,21 +8,4 @@
 # details.
 # Docs: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options
 run:debug -- --node_options=--inspect-brk
-
-# Enable runfiles on all platforms. Runfiles are on by default on Linux and MacOS but off on
-# Windows.
-#
-# In general, rules_js and derivate rule sets assume that runfiles are enabled and do not support no
-# runfiles case because it does not scale to teach all Node.js tools to use the runfiles manifest.
-#
-# If you are developing on Windows, you must either run bazel with administrator privileges or
-# enable developer mode. If you do not you may hit this error on Windows:
-#
-#   Bazel needs to create symlinks to build the runfiles tree.
-#   Creating symlinks on Windows requires one of the following:
-#       1. Bazel is run with administrator privileges.
-#       2. The system version is Windows 10 Creators Update (1703) or later
-#          and developer mode is enabled.
-#
-# Docs: https://bazel.build/reference/command-line-reference#flag--enable_runfiles
-build --enable_runfiles
+test:debug --test_env=NODE_OPTIONS=--inspect-brk

--- a/pnpm-workspaces/.aspect/bazelrc/performance.bazelrc
+++ b/pnpm-workspaces/.aspect/bazelrc/performance.bazelrc
@@ -1,12 +1,3 @@
-# Speed up all builds by not checking if output files have been modified. Lets you make changes to
-# the output tree without triggering a build for local debugging. For example, you can modify
-# [rules_js](https://github.com/aspect-build/rules_js) 3rd party npm packages in the output tree
-# when local debugging.
-# Docs: https://github.com/bazelbuild/bazel/blob/1af61b21df99edc2fc66939cdf14449c2661f873/src/main/java/com/google/devtools/build/lib/pkgcache/PackageOptions.java#L185
-build --noexperimental_check_output_files
-fetch --noexperimental_check_output_files
-query --noexperimental_check_output_files
-
 # Don't apply `--noremote_upload_local_results` and `--noremote_accept_cached` to the disk cache.
 # If you have both `--noremote_upload_local_results` and `--disk_cache`, then this fixes a bug where
 # Bazel doesn't write to the local disk cache as it treats as a remote cache.
@@ -28,11 +19,15 @@ build --experimental_reuse_sandbox_directories
 # Docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
 build --nolegacy_external_runfiles
 
-# Some actions are always IO-intensive but require little compute. It's wasteful to put the output
-# in the remote cache, it just saturates the network and fills the cache storage causing earlier
-# evictions. It's also not worth sending them for remote execution.
-# For actions like PackageTar it's usually faster to just re-run the work locally every time.
-# You'll have to look at an execution log to figure out what other action mnemonics you care about.
-# In some cases you may need to patch rulesets to add a mnemonic to actions that don't have one.
-# https://bazel.build/reference/command-line-reference#flag--modify_execution_info
-build --modify_execution_info=PackageTar=+no-remote
+# Avoid creating a runfiles tree for binaries or tests until it is needed.
+# Docs: https://bazel.build/reference/command-line-reference#flag--build_runfile_links
+# See https://github.com/bazelbuild/bazel/issues/6627
+#
+# This may break local workflows that `build` a binary target, then run the resulting program
+# outside of `bazel run`. In those cases, the script will need to call
+# `bazel build --build_runfile_links //my/binary:target` and then execute the resulting program.
+build --nobuild_runfile_links
+
+# Needed prior to Bazel 8; see
+# https://github.com/bazelbuild/bazel/issues/20577
+coverage --build_runfile_links

--- a/pnpm-workspaces/.aspect/cli/config.yaml
+++ b/pnpm-workspaces/.aspect/cli/config.yaml
@@ -1,0 +1,3 @@
+configure:
+  languages:
+    javascript: true

--- a/pnpm-workspaces/.bazelrc
+++ b/pnpm-workspaces/.bazelrc
@@ -19,6 +19,8 @@ import %workspace%/.aspect/bazelrc/bazel6.bazelrc
 ### YOUR PROJECT SPECIFIC SETTINGS GO HERE ###
 common --enable_bzlmod
 
+common --@aspect_rules_ts//ts:skipLibCheck=always
+
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This
 # should be last statement in this config so the user configuration is able to overwrite flags from

--- a/pnpm-workspaces/BUILD.bazel
+++ b/pnpm-workspaces/BUILD.bazel
@@ -1,15 +1,30 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:tsconfig-to-swcconfig/package_json.bzl", tsconfig_to_swcconfig = "bin")
 
-# link all dependencies from root package.json
+# aspect:generation_mode update
+
+# aspect:map_kind ts_project ts_project //:defs.bzl
+
+# aspect:js enabled
+# aspect:js_tsconfig enabled
+# aspect:js_npm_package enabled
+
+# aspect:js_files **/*.{js,ts}
+# aspect:js_npm_package_target_name pkg
+# aspect:js_package_rule_kind js_library
+# aspect:js_project_naming_convention tsc
+
 npm_link_all_packages(name = "node_modules")
 
 ts_config(
     name = "tsconfig",
     src = "tsconfig.json",
     visibility = ["//visibility:public"],
-    deps = ["//:node_modules/@tsconfig/node16-strictest"],
+    deps = [
+        "//:node_modules/@tsconfig/node16-strictest",  #keep
+    ],
 )
 
 tsconfig_to_swcconfig.t2s(
@@ -17,4 +32,9 @@ tsconfig_to_swcconfig.t2s(
     srcs = ["tsconfig.json"],
     stdout = ".swcrc",
     visibility = ["//:__subpackages__"],
+)
+
+js_library(
+    name = "pkg",
+    srcs = ["package.json"],
 )

--- a/pnpm-workspaces/MODULE.bazel
+++ b/pnpm-workspaces/MODULE.bazel
@@ -6,7 +6,6 @@ bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "platforms", version = "0.0.6")
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
-
 npm.npm_translate_lock(
     name = "npm",
     bins = {
@@ -20,7 +19,6 @@ npm.npm_translate_lock(
     pnpm_lock = "//:pnpm-lock.yaml",
     verify_node_modules_ignored = "//:.bazelignore",
 )
-
 use_repo(npm, "npm")
 
 rules_ts_ext = use_extension(
@@ -28,7 +26,5 @@ rules_ts_ext = use_extension(
     "ext",
     dev_dependency = True,
 )
-
 rules_ts_ext.deps(ts_version_from = "//:package.json")
-
 use_repo(rules_ts_ext, "npm_typescript")

--- a/pnpm-workspaces/MODULE.bazel
+++ b/pnpm-workspaces/MODULE.bazel
@@ -1,9 +1,9 @@
-bazel_dep(name = "aspect_bazel_lib", version = "1.33.0")
-bazel_dep(name = "aspect_rules_js", version = "1.31.0")
-bazel_dep(name = "aspect_rules_swc", version = "1.1.0")
-bazel_dep(name = "aspect_rules_ts", version = "1.4.5")
-bazel_dep(name = "bazel_skylib", version = "1.4.2")
-bazel_dep(name = "platforms", version = "0.0.6")
+bazel_dep(name = "aspect_bazel_lib", version = "2.9.1")
+bazel_dep(name = "aspect_rules_js", version = "2.1.0")
+bazel_dep(name = "aspect_rules_swc", version = "2.0.1")
+bazel_dep(name = "aspect_rules_ts", version = "3.2.1")
+bazel_dep(name = "bazel_skylib", version = "1.6.1")
+bazel_dep(name = "platforms", version = "0.0.10")
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
 npm.npm_translate_lock(
@@ -15,6 +15,7 @@ npm.npm_translate_lock(
             "tsserver=./bin/tsserver",
         ],
     },
+    npm_package_target_name = "pkg",
     npmrc = "//:.npmrc",
     pnpm_lock = "//:pnpm-lock.yaml",
     verify_node_modules_ignored = "//:.bazelignore",

--- a/pnpm-workspaces/apps/alpha/BUILD.bazel
+++ b/pnpm-workspaces/apps/alpha/BUILD.bazel
@@ -1,8 +1,6 @@
-load("@aspect_rules_swc//swc:defs.bzl", "swc")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
-load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@npm//:defs.bzl", "npm_link_all_packages")
+load("//:defs.bzl", "ts_project")
 
 npm_link_all_packages(name = "node_modules")
 
@@ -10,10 +8,6 @@ ts_project(
     name = "pkg",
     srcs = ["src/main.ts"],
     declaration = True,
-    transpiler = partial.make(
-        swc,
-        swcrc = "//:.swcrc",
-    ),
     tsconfig = "//:tsconfig",
     deps = [
         ":node_modules/inspirational-quotes",  # this uses the version defined in the local package.json

--- a/pnpm-workspaces/apps/alpha/BUILD.bazel
+++ b/pnpm-workspaces/apps/alpha/BUILD.bazel
@@ -7,7 +7,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 npm_link_all_packages(name = "node_modules")
 
 ts_project(
-    name = "alpha",
+    name = "pkg",
     srcs = ["src/main.ts"],
     declaration = True,
     transpiler = partial.make(
@@ -26,6 +26,6 @@ ts_project(
 
 js_binary(
     name = "main",
-    data = [":alpha"],
+    data = [":pkg"],
     entry_point = "src/main.js",
 )

--- a/pnpm-workspaces/apps/alpha/BUILD.bazel
+++ b/pnpm-workspaces/apps/alpha/BUILD.bazel
@@ -1,11 +1,11 @@
-load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//:defs.bzl", "ts_project")
 
 npm_link_all_packages(name = "node_modules")
 
 ts_project(
-    name = "pkg",
+    name = "tsc",
     srcs = ["src/main.ts"],
     declaration = True,
     tsconfig = "//:tsconfig",
@@ -13,9 +13,15 @@ ts_project(
         ":node_modules/inspirational-quotes",  # this uses the version defined in the local package.json
         "//:node_modules/@bazel-poc/one",
         "//:node_modules/@bazel-poc/shared",
-        "//:node_modules/@types/node",
+        "//:node_modules/@types/node",  # keep
         "//:node_modules/star-wars-quotes",
     ],
+)
+
+js_library(
+    name = "pkg",
+    srcs = ["package.json"],
+    deps = [":tsc"],
 )
 
 js_binary(

--- a/pnpm-workspaces/apps/beta/BUILD.bazel
+++ b/pnpm-workspaces/apps/beta/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
 
 js_library(
-    name = "beta",
+    name = "pkg",
     srcs = ["src/main.js"],
     deps = [
         "//:node_modules/@bazel-poc/shared",
@@ -13,6 +13,6 @@ js_library(
 
 js_binary(
     name = "main",
-    data = [":beta"],
+    data = [":pkg"],
     entry_point = "src/main.js",
 )

--- a/pnpm-workspaces/apps/beta/BUILD.bazel
+++ b/pnpm-workspaces/apps/beta/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
 
 js_library(
-    name = "pkg",
+    name = "tsc",
     srcs = ["src/main.js"],
     deps = [
         "//:node_modules/@bazel-poc/shared",
@@ -13,6 +13,6 @@ js_library(
 
 js_binary(
     name = "main",
-    data = [":pkg"],
+    data = [":tsc"],
     entry_point = "src/main.js",
 )

--- a/pnpm-workspaces/defs.bzl
+++ b/pnpm-workspaces/defs.bzl
@@ -1,0 +1,19 @@
+"""
+@aspect_rules_ts macros to enable custom config, transpiler.
+"""
+
+load("@aspect_rules_ts//ts:defs.bzl", _ts_project = "ts_project")
+load("@aspect_rules_swc//swc:defs.bzl", "swc")
+load("@bazel_skylib//lib:partial.bzl", "partial")
+
+def ts_project(name, **kwargs):
+    _ts_project(
+        name = name,
+        declaration = kwargs.pop("declaration", True),
+        transpiler = partial.make(
+            swc,
+            swcrc = "//:.swcrc",
+        ),
+        tsconfig = kwargs.pop("tsconfig", "//:tsconfig"),
+        **kwargs
+    )

--- a/pnpm-workspaces/packages/first/BUILD.bazel
+++ b/pnpm-workspaces/packages/first/BUILD.bazel
@@ -2,12 +2,10 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 
 # make this library available via node_modules
 npm_package(
-    name = "first",
+    name = "pkg",
     srcs = [
         "package.json",
         "src/main.js",
     ],
-    # This is a perf improvement; the default will be flipped to False in rules_js 2.0
-    include_runfiles = False,
     visibility = ["//visibility:public"],
 )

--- a/pnpm-workspaces/packages/first/BUILD.bazel
+++ b/pnpm-workspaces/packages/first/BUILD.bazel
@@ -1,11 +1,16 @@
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@npm//:defs.bzl", "npm_link_all_packages")
 
-# make this library available via node_modules
-npm_package(
+npm_link_all_packages(name = "node_modules")
+
+js_library(
+    name = "tsc",
+    srcs = ["src/main.js"],
+)
+
+js_library(
     name = "pkg",
-    srcs = [
-        "package.json",
-        "src/main.js",
-    ],
+    srcs = ["package.json"],
     visibility = ["//visibility:public"],
+    deps = [":tsc"],
 )

--- a/pnpm-workspaces/packages/one/BUILD.bazel
+++ b/pnpm-workspaces/packages/one/BUILD.bazel
@@ -1,22 +1,22 @@
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//:defs.bzl", "ts_project")
 
+npm_link_all_packages(name = "node_modules")
+
 ts_project(
-    name = "one_lib",
+    name = "tsc",
     srcs = ["src/main.ts"],
     declaration = True,
     tsconfig = "//:tsconfig",
     deps = [
-        "//:node_modules/@types/node",
+        "//:node_modules/@types/node",  # keep
     ],
 )
 
-# make this library available via node_modules
-npm_package(
+js_library(
     name = "pkg",
-    srcs = [
-        "package.json",
-        ":one_lib",
-    ],
+    srcs = ["package.json"],
     visibility = ["//visibility:public"],
+    deps = [":tsc"],
 )

--- a/pnpm-workspaces/packages/one/BUILD.bazel
+++ b/pnpm-workspaces/packages/one/BUILD.bazel
@@ -1,16 +1,10 @@
-load("@aspect_rules_swc//swc:defs.bzl", "swc")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@bazel_skylib//lib:partial.bzl", "partial")
+load("//:defs.bzl", "ts_project")
 
 ts_project(
     name = "one_lib",
     srcs = ["src/main.ts"],
     declaration = True,
-    transpiler = partial.make(
-        swc,
-        swcrc = "//:.swcrc",
-    ),
     tsconfig = "//:tsconfig",
     deps = [
         "//:node_modules/@types/node",

--- a/pnpm-workspaces/packages/one/BUILD.bazel
+++ b/pnpm-workspaces/packages/one/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 
 ts_project(
-    name = "one_ts",
+    name = "one_lib",
     srcs = ["src/main.ts"],
     declaration = True,
     transpiler = partial.make(
@@ -19,12 +19,10 @@ ts_project(
 
 # make this library available via node_modules
 npm_package(
-    name = "one",
+    name = "pkg",
     srcs = [
         "package.json",
-        ":one_ts",
+        ":one_lib",
     ],
-    # This is a perf improvement; the default will be flipped to False in rules_js 2.0
-    include_runfiles = False,
     visibility = ["//visibility:public"],
 )

--- a/pnpm-workspaces/packages/shared/BUILD.bazel
+++ b/pnpm-workspaces/packages/shared/BUILD.bazel
@@ -4,7 +4,7 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 
 ts_project(
-    name = "shared_ts",
+    name = "shared_lib",
     srcs = ["src/main.ts"],
     declaration = True,
     transpiler = partial.make(
@@ -19,12 +19,10 @@ ts_project(
 
 # make this library available via node_modules
 npm_package(
-    name = "shared",
+    name = "pkg",
     srcs = [
         "package.json",
         "src/main.js",
     ],
-    # This is a perf improvement; the default will be flipped to False in rules_js 2.0
-    include_runfiles = False,
     visibility = ["//visibility:public"],
 )

--- a/pnpm-workspaces/packages/shared/BUILD.bazel
+++ b/pnpm-workspaces/packages/shared/BUILD.bazel
@@ -1,22 +1,22 @@
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//:defs.bzl", "ts_project")
 
+npm_link_all_packages(name = "node_modules")
+
 ts_project(
-    name = "shared_lib",
+    name = "tsc",
     srcs = ["src/main.ts"],
     declaration = True,
     tsconfig = "//:tsconfig",
     deps = [
-        "//:node_modules/@types/node",
+        "//:node_modules/@types/node",  # keep
     ],
 )
 
-# make this library available via node_modules
-npm_package(
+js_library(
     name = "pkg",
-    srcs = [
-        "package.json",
-        "src/main.js",
-    ],
+    srcs = ["package.json"],
     visibility = ["//visibility:public"],
+    deps = [":tsc"],
 )

--- a/pnpm-workspaces/packages/shared/BUILD.bazel
+++ b/pnpm-workspaces/packages/shared/BUILD.bazel
@@ -1,16 +1,10 @@
-load("@aspect_rules_swc//swc:defs.bzl", "swc")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
-load("@bazel_skylib//lib:partial.bzl", "partial")
+load("//:defs.bzl", "ts_project")
 
 ts_project(
     name = "shared_lib",
     srcs = ["src/main.ts"],
     declaration = True,
-    transpiler = partial.make(
-        swc,
-        swcrc = "//:.swcrc",
-    ),
     tsconfig = "//:tsconfig",
     deps = [
         "//:node_modules/@types/node",

--- a/pnpm-workspaces/packages/two/BUILD.bazel
+++ b/pnpm-workspaces/packages/two/BUILD.bazel
@@ -2,7 +2,7 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 
 # make this library available via node_modules
 npm_package(
-    name = "two",
+    name = "pkg",
     srcs = [
         "package.json",
         "src/main.js",
@@ -11,7 +11,5 @@ npm_package(
         "//:node_modules/@bazel-poc/first",
         "//:node_modules/cowsay",
     ],
-    # This is a perf improvement; the default will be flipped to False in rules_js 2.0
-    include_runfiles = False,
     visibility = ["//visibility:public"],
 )

--- a/pnpm-workspaces/packages/two/BUILD.bazel
+++ b/pnpm-workspaces/packages/two/BUILD.bazel
@@ -1,15 +1,20 @@
-load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@npm//:defs.bzl", "npm_link_all_packages")
 
-# make this library available via node_modules
-npm_package(
-    name = "pkg",
-    srcs = [
-        "package.json",
-        "src/main.js",
-    ],
-    data = [
+npm_link_all_packages(name = "node_modules")
+
+js_library(
+    name = "tsc",
+    srcs = ["src/main.js"],
+    deps = [
         "//:node_modules/@bazel-poc/first",
         "//:node_modules/cowsay",
     ],
+)
+
+js_library(
+    name = "pkg",
+    srcs = ["package.json"],
     visibility = ["//visibility:public"],
+    deps = [":tsc"],
 )


### PR DESCRIPTION
Update rulesets, fully generate BUILDs, update to latest recommendations for rule naming, use of `js_library` for packages etc.