### PR TITLE
chore: update gazelle generation in pnpm-workspaces examples

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,5 +1,5 @@
 BAZELISK_BASE_URL=https://static.aspect.build/aspect
-USE_BAZEL_VERSION=aspect/2024.41.17
+USE_BAZEL_VERSION=aspect/2024.42.3
 
 # Aspect CLI (aspect) is wrapper for Bazel, built on top of Bazelisk, that adds
 # additional features and extensibility to the popular polyglot build system from Google.

--- a/pnpm-workspaces/BUILD.bazel
+++ b/pnpm-workspaces/BUILD.bazel
@@ -37,4 +37,5 @@ tsconfig_to_swcconfig.t2s(
 js_library(
     name = "pkg",
     srcs = ["package.json"],
+    visibility = ["//visibility:public"],
 )

--- a/pnpm-workspaces/apps/alpha/BUILD.bazel
+++ b/pnpm-workspaces/apps/alpha/BUILD.bazel
@@ -10,10 +10,10 @@ ts_project(
     declaration = True,
     tsconfig = "//:tsconfig",
     deps = [
-        ":node_modules/inspirational-quotes",  # this uses the version defined in the local package.json
+        ":node_modules/inspirational-quotes",
         "//:node_modules/@bazel-poc/one",
         "//:node_modules/@bazel-poc/shared",
-        "//:node_modules/@types/node",  # keep
+        "//:node_modules/@types/node",
         "//:node_modules/star-wars-quotes",
     ],
 )
@@ -21,6 +21,7 @@ ts_project(
 js_library(
     name = "pkg",
     srcs = ["package.json"],
+    visibility = ["//visibility:public"],
     deps = [":tsc"],
 )
 

--- a/pnpm-workspaces/apps/alpha/src/main.ts
+++ b/pnpm-workspaces/apps/alpha/src/main.ts
@@ -1,3 +1,4 @@
+import { platform, arch } from 'node:os';
 import { one } from '@bazel-poc/one';
 import { shared } from '@bazel-poc/shared';
 import { getRandomQuote } from 'inspirational-quotes';
@@ -7,3 +8,5 @@ shared();
 one();
 console.log(getRandomQuote());
 console.log(quotes());
+console.log('Platform: ' + platform());
+console.log('Architecture: ' + arch());

--- a/pnpm-workspaces/packages/one/BUILD.bazel
+++ b/pnpm-workspaces/packages/one/BUILD.bazel
@@ -9,9 +9,7 @@ ts_project(
     srcs = ["src/lib.ts"],
     declaration = True,
     tsconfig = "//:tsconfig",
-    deps = [
-        "//:node_modules/@types/node",  # keep
-    ],
+    deps = ["//:node_modules/@types/node"],
 )
 
 js_library(

--- a/pnpm-workspaces/packages/one/src/lib.ts
+++ b/pnpm-workspaces/packages/one/src/lib.ts
@@ -1,3 +1,4 @@
+import { format } from 'node:util';
 export function one() {
-  console.log('I am One, not Two!');
+  console.log(format('I am %s, not %s!', 'One', 'Two'));
 }

--- a/pnpm-workspaces/packages/shared/BUILD.bazel
+++ b/pnpm-workspaces/packages/shared/BUILD.bazel
@@ -9,9 +9,7 @@ ts_project(
     srcs = ["src/lib.ts"],
     declaration = True,
     tsconfig = "//:tsconfig",
-    deps = [
-        "//:node_modules/@types/node",  # keep
-    ],
+    deps = ["//:node_modules/@types/node"],
 )
 
 js_library(

--- a/pnpm-workspaces/packages/shared/src/lib.ts
+++ b/pnpm-workspaces/packages/shared/src/lib.ts
@@ -1,3 +1,4 @@
+import { format } from 'node:util';
 export function shared() {
-  console.log('Sharing is indeed caring!');
+  console.log(format('Sharing is indeed %s!', 'caring'));
 }


### PR DESCRIPTION
BUILD files can now be cleared out and fully re-generated with `configure` without any diff