### PR TITLE
Update rules_js_to_rules_nodejs_adapter.bzl for rules_js 2.0

### DIFF
--- a/rules_nodejs_to_rules_js_migration/bazel/rules_js_to_rules_nodejs_adapter.bzl
+++ b/rules_nodejs_to_rules_js_migration/bazel/rules_js_to_rules_nodejs_adapter.bzl
@@ -11,7 +11,7 @@ def _impl(ctx):
     for dep in ctx.attr.deps:
         if JsInfo in dep:
             files_depsets.append(dep[JsInfo].transitive_sources)
-            files_depsets.append(dep[JsInfo].transitive_declarations)
+            files_depsets.append(dep[JsInfo].transitive_types)
 
     files = []
     for file in depset(transitive = files_depsets).to_list():


### PR DESCRIPTION
This will break as it doesn't do the full upgrade, it just creates the start so that I can pull a copy of the upgraded file into our internal repo