### PR TITLE
chore: restore WORKSPACE file

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,5 +1,5 @@
 BAZELISK_BASE_URL=https://static.aspect.build/aspect
-USE_BAZEL_VERSION=aspect/2024.42.3
+USE_BAZEL_VERSION=aspect/2024.51.11
 
 # Aspect CLI (aspect) is wrapper for Bazel, built on top of Bazelisk, that adds
 # additional features and extensibility to the popular polyglot build system from Google.

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,3 @@
+# This file should be removed once issues are fixed:
+# https://github.com/bazel-contrib/bazel-gazelle/issues/2012
+# https://github.com/bazelbuild/bazel-watcher/issues/646


### PR DESCRIPTION
It was removed in #390 but that broke 'bazel configure'. Also upgrade Aspect CLI to latest while I'm here, though it didn't fix anything
