### PR TITLE
chore: mirror commits from bazel-examples to downstreams

### DIFF
--- a/.github/workflows/sync_mirrors.yaml
+++ b/.github/workflows/sync_mirrors.yaml
@@ -1,0 +1,39 @@
+# We maintain mirrors of this repo for demonstrating Aspect Workflows on other CI platforms.
+# This is documented in /.aspect/workflows/README.md.
+# The primary repo is tested on Buildkite because it's the best
+# https://buildkite.com/aspect/bazel-examples
+# When commits land there, we sync them to the others:
+# CircleCI: https://app.circleci.com/pipelines/github/aspect-build/bazel-examples-cci
+# GitHub Actions: https://github.com/aspect-build/bazel-examples-gha/actions/workflows/aspect-workflows.yaml
+name: Sync Mirrors
+on:
+  workflow_dispatch:
+  push:
+    branches: ['main']
+jobs:
+  push-cci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get a full history so all commits are present
+        uses: actions/checkout@v4
+        with:
+            path: fresh-clone
+            fetch-depth: 0
+      - working-directory: fresh-clone
+        run: |
+            eval $(ssh-agent -s)
+            ssh-add - <<< '${{ secrets.BAZEL_EXAMPLES_CCI_DEPLOY_TOKEN }}'
+            git push git@github.com:aspect-build/bazel-examples-cci.git HEAD:main
+  push-gha:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get a full history so all commits are present
+        uses: actions/checkout@v4
+        with:
+            path: fresh-clone
+            fetch-depth: 0                
+      - working-directory: fresh-clone
+        run: |
+            eval $(ssh-agent -s)
+            ssh-add - <<< '${{ secrets.BAZEL_EXAMPLES_GHA_DEPLOY_TOKEN }}'
+            git push git@github.com:aspect-build/bazel-examples-gha.git HEAD:main

--- a/.github/workflows/sync_mirrors.yaml
+++ b/.github/workflows/sync_mirrors.yaml
@@ -3,8 +3,8 @@
 # The primary repo is tested on Buildkite because it's the best
 # https://buildkite.com/aspect/bazel-examples
 # When commits land there, we sync them to the others:
-# CircleCI: https://app.circleci.com/pipelines/github/aspect-build/bazel-examples-cci
-# GitHub Actions: https://github.com/aspect-build/bazel-examples-gha/actions/workflows/aspect-workflows.yaml
+# CircleCI: https://buildkite.com/aspect/bazel-examples-cci
+# GitHub Actions: https://buildkite.com/aspect/bazel-examples-gha
 name: Sync Mirrors
 on:
   workflow_dispatch:


### PR DESCRIPTION
Note, I put deploy public keys into each of the downstream repos, the private keys are stored in GHA secrets in this repo.

NB: this assumes that the push is a fast-forward, meaning we prevent commits to those two downstream repos directly. If it's not a fast-forward, this new GHA workflow will fail on the `git push` step.

@gregmagolan are you okay with making any GHA or CCI edits to this repo and then letting the automation push them? If not I'll have to do something fancier here to rewrite commits on top of the history of the target repo, essentially a rebase.

---

### Changes are visible to end-users: no

### Test plan
Will run the new workflow manually at first. 