### PR TITLE
Update weekly_tag.yaml

### DIFF
--- a/.github/workflows/weekly_tag.yaml
+++ b/.github/workflows/weekly_tag.yaml
@@ -1,24 +1,22 @@
 # Apply a tag to HEAD at the beginning of each week.
 # We can use this to create semver-looking tags for releases like
 # 2020.44.123+abc1234
-# See https://blog.aspect.build/versioning-releases-from-a-monorepo
 on:
-    schedule:
-      # Mondays at 5am UTC / midnight EST
-      - cron: '0 5 * * 1'
-
+  schedule:
+    # Mondays at 5am UTC / midnight EST
+    - cron: '0 5 * * 1'
 jobs:
   tagger:
     runs-on: ubuntu-latest
     steps:
-    - name: tag HEAD with [year].[week number]
-      run: |
-        curl --request POST \
-            --url https://api.github.com/repos/{{ "${{ github.repository }}" }}/git/refs \
-            --header 'authorization: Bearer {{ "${{ secrets.GITHUB_TOKEN }}" }}' \
-            --data @- << EOF
-        {
-            "ref": "refs/tags/$(date +%Y.%V)",
-            "sha": "{{ "${{ github.sha }}" }}"
-        }
-        EOF
+      - name: tag HEAD with date +%Y.%V
+        run: |
+          curl --request POST \
+              --url https://api.github.com/repos/${{ github.repository }}/git/refs \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+              --data @- << EOF
+          {
+              "ref": "refs/tags/$(date +%Y.%V)",
+              "sha": "${{ github.sha }}"
+          }
+          EOF


### PR DESCRIPTION
It has been failing for a long time in this repo. The double-curlies got doubled or escaped somehow.

Fix by copying from Silo. I'll want this to demonstrate continuous delivery.

