### PR TITLE
fix: don't try to run sync job from downstreams

### DIFF
--- a/.github/workflows/sync_mirrors.yaml
+++ b/.github/workflows/sync_mirrors.yaml
@@ -12,6 +12,7 @@ on:
     branches: ['main']
 jobs:
   push-cci:
+    if: github.repository == 'aspect-build/bazel-examples'
     runs-on: ubuntu-latest
     steps:
       - name: Get a full history so all commits are present
@@ -25,6 +26,7 @@ jobs:
             ssh-add - <<< '${{ secrets.BAZEL_EXAMPLES_CCI_DEPLOY_TOKEN }}'
             git push git@github.com:aspect-build/bazel-examples-cci.git HEAD:main
   push-gha:
+    if: github.repository == 'aspect-build/bazel-examples'
     runs-on: ubuntu-latest
     steps:
       - name: Get a full history so all commits are present


### PR DESCRIPTION
Fixes red X appearing on those repos, e.g. https://github.com/aspect-build/bazel-examples-gha/commit/3a12238ddd307c5843d847cb282b4c294962aa7c

Note, I tried using a matrix job to reduce duplication here, but it got very difficult to debug the SSH credentials not working. You can't just put both of them into the ssh-agent based on my testing. Not worth my time.
