### PR TITLE
chore: add a go_test so we can measure some coverage

### DIFF
--- a/oci_go_image/BUILD.bazel
+++ b/oci_go_image/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_bazel_lib//lib:testing.bzl", "assert_archive_contains")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
@@ -11,6 +11,13 @@ go_library(
     importpath = "github.com/aspect-build/bazel-examples/oci_go_image",
     visibility = ["//visibility:private"],
     deps = ["@com_github_google_go_cmp//cmp"],
+)
+
+go_test(
+    name = "app_test",
+    size = "small",
+    srcs = ["main_test.go"],
+    embed = [":app_lib"],
 )
 
 go_binary(

--- a/oci_go_image/main.go
+++ b/oci_go_image/main.go
@@ -1,10 +1,15 @@
-package main		
+package main
 
-import (		
-	"fmt"		
-	"github.com/google/go-cmp/cmp"		
-)		
+import (
+	"fmt"
 
-func main() {		
-    fmt.Println(cmp.Diff("Hello World", "Hello Go"))		
+	"github.com/google/go-cmp/cmp"
+)
+
+func Compare(str1, str2 string) string {
+	return cmp.Diff(str1, str2)
+}
+
+func main() {
+	fmt.Println(Compare("Hello World", "Hello Go"))
 }

--- a/oci_go_image/main_test.go
+++ b/oci_go_image/main_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestGenerateNumber(t *testing.T) {
+	result := Compare("this", "that")
+
+	if result == "" {
+		t.Error("got an empty string")
+	}
+}

--- a/oci_go_image/main_test.go
+++ b/oci_go_image/main_test.go
@@ -1,13 +1,14 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
-func TestGenerateNumber(t *testing.T) {
+func TestCompare(t *testing.T) {
 	result := Compare("this", "that")
 
-	if result == "" {
-		t.Error("got an empty string")
+	if !strings.Contains(result, "this") {
+		t.Error("expected a diff containing 'this' but got", result)
 	}
 }


### PR DESCRIPTION
locally running `bazel coverage` on this target

```
% cat /private/var/tmp/_bazel_alexeagle/2442372bc9d5c407aa13d3b43880afe0/execroot/_main/bazel-out/darwin_arm64-fastbuild/testlogs/oci_go_image/app_test/coverage.dat
SF:oci_go_image/main.go
FNF:0
FNH:0
DA:9,1
```