### PR TITLE
feat: generate angular-ngc sass_binary targets with aspect configure plugin

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,5 +1,5 @@
 BAZELISK_BASE_URL=https://static.aspect.build/aspect
-USE_BAZEL_VERSION=aspect/2024.51.11
+USE_BAZEL_VERSION=aspect/2025.08.18
 
 # Aspect CLI (aspect) is wrapper for Bazel, built on top of Bazelisk, that adds
 # additional features and extensibility to the popular polyglot build system from Google.

--- a/angular-ngc/.aspect/cli/config.yaml
+++ b/angular-ngc/.aspect/cli/config.yaml
@@ -1,0 +1,5 @@
+configure:
+  languages:
+    javascript: true
+  plugins:
+    - .aspect/cli/postcss.star

--- a/angular-ngc/.aspect/cli/postcss.star
+++ b/angular-ngc/.aspect/cli/postcss.star
@@ -1,0 +1,46 @@
+aspect.register_rule_kind("sass_binary", {
+    "From": "//tools:sass.bzl",
+    "MergeableAttrs": ["srcs"],
+    "ResolveAttrs": ["deps"],
+})
+
+def declare_postcss(ctx):
+    if len(ctx.sources) == 0:
+        ctx.targets.remove("css")
+        return
+
+    imports = []
+    for file in ctx.sources:
+        imports.extend([
+            aspect.Import(
+                id = i.captures["import"],
+                provider = "js",
+                src = file.path,
+            )
+            for i in file.query_results["imports"]
+        ])
+
+    ctx.targets.add(
+        name = "css",
+        kind = "sass_binary",
+        attrs = {
+            "srcs": [src.path for src in ctx.sources],
+            "deps": imports,
+        },
+    )
+
+aspect.register_configure_extension(
+    id = "postcss",
+    prepare = lambda _: aspect.PrepareResult(
+        sources = [
+            aspect.SourceExtensions(".scss"),
+        ],
+        queries = {
+            "imports": aspect.RegexQuery(
+                filter = "**/*.scss",
+                expression = """@use\\s+['"](?P<import>[^'"]+)['"]""",
+            ),
+        },
+    ),
+    declare = declare_postcss,
+)

--- a/angular-ngc/BUILD.bazel
+++ b/angular-ngc/BUILD.bazel
@@ -1,6 +1,9 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 
+# aspect:js disabled
+# aspect:generation_mode update
+
 # Link npm packages
 npm_link_all_packages(name = "node_modules")
 

--- a/angular-ngc/applications/demo/BUILD.bazel
+++ b/angular-ngc/applications/demo/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
+load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//:defs.bzl", "ng_application")
 

--- a/angular-ngc/applications/grpc/BUILD.bazel
+++ b/angular-ngc/applications/grpc/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
+load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//:defs.bzl", "ng_application")
 

--- a/angular-ngc/packages/connect/src/proto/BUILD.bazel
+++ b/angular-ngc/packages/connect/src/proto/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@aspect_rules_ts//ts:proto.bzl", "ts_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/angular-ngc/packages/lib-a/BUILD.bazel
+++ b/angular-ngc/packages/lib-a/BUILD.bazel
@@ -8,11 +8,8 @@ npm_link_all_packages(name = "node_modules")
 
 sass_binary(
     name = "css",
-    srcs = glob(["src/**/*.scss"]),
-    deps = [
-        "//:node_modules/@angular/cdk",
-        "//:node_modules/@angular/material",
-    ],
+    srcs = ["src/lib/lib-a.component.scss"],
+    deps = ["//:node_modules/@angular/material"],
 )
 
 ng_pkg(


### PR DESCRIPTION
Upgrade the aspect-cli to the latest pro version. Generate the angular-ngc `sass_binary` targets automatically.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Add example aspect orion plugin for BUILD generation.

### Test plan

- Covered by existing test cases
