### PR TITLE
refactor: use Bazel 8 feature to ignore node_modules

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -23,9 +23,3 @@ prisma/
 rules_nodejs_to_rules_js_migration/
 ts_project_transpiler/
 vercel_pkg/
-
-# node_modules and dist directories that should be ignored:
-qwik/app/node_modules/
-qwik/app/dist/
-qwik/lib/node_modules/
-qwik/lib/dist/

--- a/REPO.bazel
+++ b/REPO.bazel
@@ -1,0 +1,10 @@
+"""Global repository settings.
+
+See https://bazel.build/rules/lib/globals/repo
+"""
+ignore_directories([
+    "**/dist",
+    "**/node_modules",
+    "**/.pytest_cache",
+    "**/__pycache__",
+])


### PR DESCRIPTION
pre-factor for Angular example

---

### Changes are visible to end-users: no
