### PR TITLE
chore: push to an anonymous registry

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -15,13 +15,6 @@ tasks:
       coverage:
         codecov_upload: true
   - delivery:
-      hooks:
-        - type: before_task
-          command: |
-            mkdir -p /tmp/docker-config
-            echo '{}' > /tmp/docker-config/config.json
-            DOCKER_CONFIG=/tmp/docker-config \
-              echo $GITHUB_TOKEN | docker login $REGISTRY -u $GITHUB_ACTOR --password-stdin
       rules:
         - deliverable: 'kind("oci_push rule", //...)'
 notifications:

--- a/oci_go_image/BUILD.bazel
+++ b/oci_go_image/BUILD.bazel
@@ -90,6 +90,9 @@ container_structure_test(
 oci_push(
     name = "push",
     image = ":transitioned_image",
-    remote_tags = ["latest"],
-    repository = "ghcr.io/aspect-build/oci_go_image_example",
+    remote_tags = [
+        "latest",
+        "24h",
+    ],
+    repository = "ttl.sh/aspect-build/oci_go_image_example",
 )


### PR DESCRIPTION
avoids having the auth problem of exposing credentials on a public repo
