### PR TITLE
chore: turn on configure checking

### DIFF
--- a/.aspect/cli/rules_cc.star
+++ b/.aspect/cli/rules_cc.star
@@ -48,10 +48,11 @@ def add_target(ctx, file, hdrs = []):
         attrs["size"] = "small"
     elif not is_main:
         attrs["visibility"] = ["//:__subpackages__"]
+    rule_kind = "cc_test" if is_test else "cc_binary" if is_main else "cc_library"
 
     ctx.targets.add(
-        name = file.path[:file.path.rindex(".")] + "_lib",
-        kind = "cc_test" if is_test else "cc_binary" if is_main else "cc_library",
+        name = file.path[:file.path.rindex(".")] + ("_lib" if rule_kind == "cc_library" else ""),
+        kind = rule_kind,
         attrs = attrs,
         symbols = [aspect.Symbol(
             id = "/".join([ctx.rel, basename]) if ctx.rel else basename,

--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -1,5 +1,6 @@
 # See https://docs.aspect.build/workflows/configuration
 tasks:
+  - configure:
   - checkout:
       update_strategy: rebase
   - lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ workflows:
         requires:
         - aw-test
         workspace: .
+    - aw-configure:
+        context: []
+        workspace: .
     - aw-format:
         context: []
         workspace: .
@@ -98,6 +101,50 @@ jobs:
         command: rosetta run delivery
         name: Delivery
         no_output_timeout: 180m
+    working_directory: /mnt/ephemeral/workdir
+  aw-configure:
+    environment:
+      ASPECT_WORKFLOWS_CIRCLE_PIPELINE_NUMBER: << pipeline.number >>
+      ASPECT_WORKFLOWS_CIRCLE_PIPELINE_PROJECT_TYPE: << pipeline.project.type >>
+      ASPECT_WORKFLOWS_CIRCLE_WORKFLOW_BASE_NAME: aspect-workflows
+      ASPECT_WORKFLOWS_CONFIG: .aspect/workflows/config.yaml
+      ASPECT_WORKFLOWS_WORKSPACE: << parameters.workspace >>
+      XDG_CACHE_HOME: /mnt/ephemeral/caches
+    machine: true
+    parameters:
+      delivery_manifest:
+        default: true
+        type: boolean
+      workspace:
+        type: string
+    resource_class: aspect-build/aspect-default
+    steps:
+    - run:
+        command: /etc/aspect/workflows/bin/configure_workflows_env
+        name: Workflows environment
+    - checkout
+    - run:
+        command: rm -rf /workflows/artifacts /workflows/testlogs
+        name: Prepare archive directories
+    - run:
+        command: /etc/aspect/workflows/bin/agent_health_check
+        name: Agent health check
+        no_output_timeout: 180m
+    - run:
+        command: rosetta run checkout
+        name: Checkout health
+        no_output_timeout: 180m
+    - run:
+        command: rosetta run configure --workspace << parameters.workspace >>
+        name: Configure
+        no_output_timeout: 180m
+    - store_artifacts:
+        path: /workflows/artifacts
+    - run:
+        command: rosetta run finalization
+        name: Finalization
+        no_output_timeout: 10m
+        when: always
     working_directory: /mnt/ephemeral/workdir
   aw-format:
     environment:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,6 +10,8 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 # aspect:js_package_rule_kind js_library
 # aspect:js_project_naming_convention tsc
 
+# TODO(alex): refactor this folder to follow python gazelle conventions
+# gazelle:exclude py_mypy
 package(default_visibility = ["//:__subpackages__"])
 
 npm_link_all_packages(name = "node_modules")
@@ -26,6 +28,7 @@ exports_files(
         ".shellcheckrc",
         "buf.yaml",
         "checkstyle.xml",
+        "gazelle_python.yaml",
         "pmd.xml",
         "pyproject.toml",
     ],

--- a/gazelle_python.yaml
+++ b/gazelle_python.yaml
@@ -5,66 +5,77 @@
 
 manifest:
   modules_mapping:
+    3204bda914b7f2c6f497__mypyc: mypy
+    certifi: certifi
+    charset_normalizer: charset_normalizer
+    click: click
+    coverage: coverage
+    cowsay: cowsay
+    docker: docker
+    dotenv: python_dotenv
     google.protobuf: protobuf
-    google.protobuf.any_pb2: protobuf
-    google.protobuf.api_pb2: protobuf
-    google.protobuf.compiler: protobuf
-    google.protobuf.compiler.plugin_pb2: protobuf
-    google.protobuf.descriptor: protobuf
-    google.protobuf.descriptor_database: protobuf
-    google.protobuf.descriptor_pb2: protobuf
-    google.protobuf.descriptor_pool: protobuf
-    google.protobuf.duration_pb2: protobuf
-    google.protobuf.empty_pb2: protobuf
-    google.protobuf.field_mask_pb2: protobuf
-    google.protobuf.internal: protobuf
-    google.protobuf.internal.api_implementation: protobuf
-    google.protobuf.internal.builder: protobuf
-    google.protobuf.internal.containers: protobuf
-    google.protobuf.internal.decoder: protobuf
-    google.protobuf.internal.encoder: protobuf
-    google.protobuf.internal.enum_type_wrapper: protobuf
-    google.protobuf.internal.extension_dict: protobuf
-    google.protobuf.internal.field_mask: protobuf
-    google.protobuf.internal.message_listener: protobuf
-    google.protobuf.internal.python_edition_defaults: protobuf
-    google.protobuf.internal.python_message: protobuf
-    google.protobuf.internal.testing_refleaks: protobuf
-    google.protobuf.internal.type_checkers: protobuf
-    google.protobuf.internal.well_known_types: protobuf
-    google.protobuf.internal.wire_format: protobuf
-    google.protobuf.json_format: protobuf
-    google.protobuf.message: protobuf
-    google.protobuf.message_factory: protobuf
-    google.protobuf.proto_builder: protobuf
-    google.protobuf.pyext: protobuf
-    google.protobuf.pyext.cpp_message: protobuf
-    google.protobuf.reflection: protobuf
-    google.protobuf.service: protobuf
-    google.protobuf.service_reflection: protobuf
-    google.protobuf.source_context_pb2: protobuf
-    google.protobuf.struct_pb2: protobuf
-    google.protobuf.symbol_database: protobuf
-    google.protobuf.testdata: protobuf
-    google.protobuf.text_encoding: protobuf
-    google.protobuf.text_format: protobuf
-    google.protobuf.timestamp_pb2: protobuf
-    google.protobuf.type_pb2: protobuf
-    google.protobuf.unknown_fields: protobuf
-    google.protobuf.util: protobuf
-    google.protobuf.wrappers_pb2: protobuf
+    idna: idna
     iniconfig: iniconfig
-    iniconfig.exceptions: iniconfig
+    mypy: mypy
+    mypy_extensions: mypy_extensions
+    mypyc: mypy
     packaging: packaging
-    packaging.markers: packaging
-    packaging.metadata: packaging
-    packaging.requirements: packaging
-    packaging.specifiers: packaging
-    packaging.tags: packaging
-    packaging.utils: packaging
-    packaging.version: packaging
     pluggy: pluggy
     py: pytest
+    pydantic: pydantic
     pytest: pytest
+    requests: requests
+    testcontainers.arangodb: testcontainers
+    testcontainers.aws: testcontainers
+    testcontainers.azurite: testcontainers
+    testcontainers.cassandra: testcontainers
+    testcontainers.chroma: testcontainers
+    testcontainers.clickhouse: testcontainers
+    testcontainers.cockroachdb: testcontainers
+    testcontainers.compose: testcontainers
+    testcontainers.core: testcontainers
+    testcontainers.cosmosdb: testcontainers
+    testcontainers.db2: testcontainers
+    testcontainers.elasticsearch: testcontainers
+    testcontainers.generic: testcontainers
+    testcontainers.google: testcontainers
+    testcontainers.influxdb: testcontainers
+    testcontainers.influxdb1: testcontainers
+    testcontainers.influxdb2: testcontainers
+    testcontainers.k3s: testcontainers
+    testcontainers.kafka: testcontainers
+    testcontainers.keycloak: testcontainers
+    testcontainers.localstack: testcontainers
+    testcontainers.mailpit: testcontainers
+    testcontainers.memcached: testcontainers
+    testcontainers.milvus: testcontainers
+    testcontainers.minio: testcontainers
+    testcontainers.mongodb: testcontainers
+    testcontainers.mqtt: testcontainers
+    testcontainers.mssql: testcontainers
+    testcontainers.mysql: testcontainers
+    testcontainers.nats: testcontainers
+    testcontainers.neo4j: testcontainers
+    testcontainers.nginx: testcontainers
+    testcontainers.ollama: testcontainers
+    testcontainers.opensearch: testcontainers
+    testcontainers.oracle: testcontainers
+    testcontainers.postgres: testcontainers
+    testcontainers.qdrant: testcontainers
+    testcontainers.rabbitmq: testcontainers
+    testcontainers.redis: testcontainers
+    testcontainers.registry: testcontainers
+    testcontainers.scylla: testcontainers
+    testcontainers.selenium: testcontainers
+    testcontainers.sftp: testcontainers
+    testcontainers.test_module_import: testcontainers
+    testcontainers.trino: testcontainers
+    testcontainers.vault: testcontainers
+    testcontainers.weaviate: testcontainers
+    tomli: tomli
+    typing_extensions: typing_extensions
+    urllib3: urllib3
+    wrapt: wrapt
   pip_repository:
     name: pip
+integrity: 2344129a8246e10083112c2e10f8d950e9e5997c657b7471cc01a0636a9e8a88

--- a/logger/backend/cmd/server/BUILD.bazel
+++ b/logger/backend/cmd/server/BUILD.bazel
@@ -9,12 +9,12 @@ go_binary(
 go_library(
     name = "server_lib",
     srcs = ["server.go"],
-    importpath = "github.com/aspect-build/codelabs/backend/cmd/server",
+    importpath = "github.com/aspect-build/bazel-examples/logger/backend/cmd/server",
     visibility = ["//visibility:private"],
     deps = [
         "//logger/schema:logger_go_proto",
-        "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_google_grpc//reflection:go_default_library",
-        "@org_golang_google_protobuf//encoding/protojson:go_default_library",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//reflection",
+        "@org_golang_google_protobuf//encoding/protojson",
     ],
 )

--- a/logger/cli/BUILD.bazel
+++ b/logger/cli/BUILD.bazel
@@ -11,7 +11,8 @@ py_binary(
     name = "cli",
     srcs = ["__main__.py"],
     main = "__main__.py",
-    deps = [requirement("requests")],
+    visibility = ["//:__subpackages__"],
+    deps = ["@pip//requests"],
 )
 
 pip_compile(

--- a/logger/schema/BUILD.bazel
+++ b/logger/schema/BUILD.bazel
@@ -13,6 +13,7 @@ proto_library(
     srcs = ["logger.proto"],
 )
 
+# gazelle:exclude *.pb.go
 go_proto_library(
     name = "logger_go_proto",
     compilers = ["@rules_go//proto:go_grpc"],

--- a/oci_go_image/BUILD.bazel
+++ b/oci_go_image/BUILD.bazel
@@ -6,7 +6,7 @@ load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
 load("@tar.bzl", "mutate", "tar")
 
 go_library(
-    name = "app_lib",
+    name = "oci_go_image_lib",
     srcs = ["main.go"],
     importpath = "github.com/aspect-build/bazel-examples/oci_go_image",
     visibility = ["//visibility:private"],
@@ -14,15 +14,15 @@ go_library(
 )
 
 go_test(
-    name = "app_test",
+    name = "oci_go_image_test",
     size = "small",
     srcs = ["main_test.go"],
-    embed = [":app_lib"],
+    embed = [":oci_go_image_lib"],
 )
 
 go_binary(
     name = "app",
-    embed = [":app_lib"],
+    embed = [":oci_go_image_lib"],
     visibility = ["//visibility:public"],
 )
 

--- a/oci_python_image/BUILD.bazel
+++ b/oci_python_image/BUILD.bazel
@@ -1,3 +1,4 @@
+# gazelle:python_root
 exports_files(
     ["requirements.txt"],
     visibility = ["//requirements:__pkg__"],

--- a/oci_python_image/hello_world/BUILD.bazel
+++ b/oci_python_image/hello_world/BUILD.bazel
@@ -3,6 +3,7 @@ load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_image_layer", "py_library
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@pip//:requirements.bzl", "requirement")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@rules_python//python:defs.bzl", "py_test")
 
 py_library(
     name = "hello_world_lib",
@@ -11,8 +12,9 @@ py_library(
         "app.py",
     ],
     imports = [".."],
+    visibility = ["//oci_python_image:__subpackages__"],
     deps = [
-        requirement("cowsay"),
+        "@pip//cowsay",
     ],
 )
 
@@ -21,6 +23,7 @@ py_binary(
     srcs = ["__main__.py"],
     imports = [".."],
     main = "__main__.py",
+    visibility = ["//oci_python_image:__subpackages__"],
     deps = [":hello_world_lib"],
 )
 
@@ -138,5 +141,22 @@ py_test(
     deps = [
         ":__test__",
         ":hello_world_lib",
+    ],
+)
+
+py_test(
+    name = "hello_world_test",
+    srcs = [
+        "app_test.py",
+        "integration_test.py",
+        ":__test__",
+    ],
+    imports = [".."],
+    main = ":__test__.py",
+    deps = [
+        ":__test__",
+        ":hello_world_lib",
+        "@pip//docker",
+        "@pip//testcontainers",
     ],
 )

--- a/oci_python_image/hello_world/BUILD.bazel
+++ b/oci_python_image/hello_world/BUILD.bazel
@@ -132,24 +132,11 @@ py_pytest_main(
 )
 
 py_test(
-    name = "unit_test",
-    size = "small",
-    srcs = [
-        "app_test.py",
-        ":__test__",
-    ],
-    main = ":__test__.py",
-    deps = [
-        ":__test__",
-        ":hello_world_lib",
-    ],
-)
-
-py_test(
     name = "hello_world_test",
+    size = "small",
+    # keep
     srcs = [
         "app_test.py",
-        "integration_test.py",
         ":__test__",
     ],
     imports = [".."],

--- a/oci_python_image/hello_world/BUILD.bazel
+++ b/oci_python_image/hello_world/BUILD.bazel
@@ -103,6 +103,7 @@ container_structure_test(
     ],
 )
 
+# keep
 py_test(
     name = "test_container",
     srcs = ["integration_test.py"],

--- a/oci_python_image/hello_world/BUILD.bazel
+++ b/oci_python_image/hello_world/BUILD.bazel
@@ -17,7 +17,7 @@ py_library(
 )
 
 py_binary(
-    name = "hello_world",
+    name = "hello_world_app",
     srcs = ["__main__.py"],
     imports = [".."],
     main = "__main__.py",
@@ -33,14 +33,14 @@ py_binary(
 #9296e9071c11: Loading layer [==================================================>]  16.24kB/16.24kB
 py_image_layer(
     name = "layers",
-    binary = ":hello_world",
+    binary = ":hello_world_app",
 )
 
 oci_image(
     name = "image",
     # This is defined by an oci.pull() call in /MODULE.bazel
     base = "@ubuntu",
-    entrypoint = ["/oci_python_image/hello_world/hello_world"],
+    entrypoint = ["/oci_python_image/hello_world/hello_world_app"],
     tars = [":layers"],
 )
 

--- a/oci_python_image/hello_world/test.yaml
+++ b/oci_python_image/hello_world/test.yaml
@@ -1,8 +1,8 @@
 # See https://github.com/GoogleContainerTools/container-structure-test#command-tests
 schemaVersion: 2.0.0
 metadataTest:
-  entrypoint: ['/oci_python_image/hello_world/hello_world']
+  entrypoint: ['/oci_python_image/hello_world/hello_world_app']
 commandTests:
   - name: run
-    command: /oci_python_image/hello_world/hello_world
+    command: /oci_python_image/hello_world/hello_world_app
     expectedOutput: ['hello py_image_layer!']

--- a/py_mypy/BUILD.bazel
+++ b/py_mypy/BUILD.bazel
@@ -1,1 +1,2 @@
+# gazelle: ignore
 exports_files(["requirements.txt"])

--- a/requirements/BUILD.bazel
+++ b/requirements/BUILD.bazel
@@ -1,7 +1,7 @@
-load("@rules_uv//uv:pip.bzl", "pip_compile")
 load("@pip//:requirements.bzl", "all_whl_requirements")
 load("@rules_python_gazelle_plugin//manifest:defs.bzl", "gazelle_python_manifest")
 load("@rules_python_gazelle_plugin//modules_mapping:def.bzl", "modules_mapping")
+load("@rules_uv//uv:pip.bzl", "pip_compile")
 
 # This rule fetches the metadata for python packages we depend on. That data is
 # required for the gazelle_python_manifest rule to update our manifest file.

--- a/requirements/BUILD.bazel
+++ b/requirements/BUILD.bazel
@@ -1,4 +1,22 @@
 load("@rules_uv//uv:pip.bzl", "pip_compile")
+load("@pip//:requirements.bzl", "all_whl_requirements")
+load("@rules_python_gazelle_plugin//manifest:defs.bzl", "gazelle_python_manifest")
+load("@rules_python_gazelle_plugin//modules_mapping:def.bzl", "modules_mapping")
+
+# This rule fetches the metadata for python packages we depend on. That data is
+# required for the gazelle_python_manifest rule to update our manifest file.
+modules_mapping(
+    name = "modules_map",
+    wheels = all_whl_requirements,
+)
+
+gazelle_python_manifest(
+    name = "gazelle_python_manifest",
+    manifest = "//:gazelle_python.yaml",
+    modules_mapping = ":modules_map",
+    pip_repository_name = "pip",
+    requirements = "//requirements:all.txt",
+)
 
 pip_compile(
     name = "runtime",

--- a/speller/announce/BUILD.bazel
+++ b/speller/announce/BUILD.bazel
@@ -8,10 +8,10 @@ cc_library(
     # srcs are the files internal to this library: .cc, .c,
     # internal-to-this-library .h, and occasionally externally
     # compiled .o. Beware of glob performance at scale.
-    srcs = glob(["*.cc"]),
+    srcs = ["announce.cc"],
     # hdrs are the public interface to this library. If they change,
     # users of this library have to recompile.
-    hdrs = glob(["*.h"]),
+    hdrs = ["announce.h"],
     visibility = ["//speller/main:__pkg__"],
     # deps are other targets needed for this code to compile. Deps are
     # made available transitively to libraries that depend on this

--- a/speller/announce/BUILD.bazel
+++ b/speller/announce/BUILD.bazel
@@ -4,7 +4,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
-    name = "announce",
+    name = "announce_lib",
     # srcs are the files internal to this library: .cc, .c,
     # internal-to-this-library .h, and occasionally externally
     # compiled .o. Beware of glob performance at scale.
@@ -17,7 +17,7 @@ cc_library(
     # made available transitively to libraries that depend on this
     # one, automatically accumulating include paths and headers.
     deps = [
-        "//speller/greeting",
+        "//speller/greeting:greeting_lib",
     ],
     # implementation_deps makes dependencies available only for compiling this
     # library, not downstream. This should speed large builds, but

--- a/speller/data_driven_tests/BUILD.bazel
+++ b/speller/data_driven_tests/BUILD.bazel
@@ -10,6 +10,7 @@ load("@rules_cc//cc:defs.bzl", "cc_test")
 # parameterization and parallelization capabilities. But those would be specific
 # to the test runner rather than generically applicable.
 
+# gazelle:exclude lookup-datatest.cc
 [
     cc_test(
         # test-001, test-002
@@ -21,7 +22,7 @@ load("@rules_cc//cc:defs.bzl", "cc_test")
             "TEST_CONFIG_FILE": "$(location :%s)" % testfile,
         },
         deps = [
-            "//speller/lookup",
+            "//speller/lookup:lookup_lib",
             "//third_party/nlohmann-json:json",
             "@googletest//:gtest_main",
         ],

--- a/speller/greeting/BUILD.bazel
+++ b/speller/greeting/BUILD.bazel
@@ -5,7 +5,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_library(
-    name = "greeting",
+    name = "greeting_lib",
     srcs = ["greeting.cc"],
     hdrs = ["greeting.h"],
     visibility = ["//speller/announce:__pkg__"],
@@ -16,7 +16,7 @@ cc_test(
     size = "small",
     srcs = ["greeting-test.cc"],
     deps = [
-        ":greeting",
+        ":greeting_lib",
         "@googletest//:gtest_main",
     ],
 )

--- a/speller/lookup/BUILD.bazel
+++ b/speller/lookup/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_library(
-    name = "lookup",
+    name = "lookup_lib",
     srcs = ["lookup.cc"],
     hdrs = ["lookup.h"],
     visibility = [
@@ -16,7 +16,7 @@ cc_test(
     size = "small",
     srcs = ["lookup-test.cc"],
     deps = [
-        ":lookup",
+        ":lookup_lib",
         "@googletest//:gtest_main",
     ],
 )

--- a/speller/main/BUILD.bazel
+++ b/speller/main/BUILD.bazel
@@ -11,8 +11,8 @@ cc_binary(
         "DICTIONARY_FILE": "$(location :dictionary)",
     },
     deps = [
-        "//speller/announce",
-        "//speller/lookup",
+        "//speller/announce:announce_lib",
+        "//speller/lookup:lookup_lib",
     ],
 )
 
@@ -20,7 +20,7 @@ cc_binary(
     name = "build-dictionary",
     srcs = ["build-dictionary.cc"],
     deps = [
-        "//speller/lookup",
+        "//speller/lookup:lookup_lib",
     ],
 )
 

--- a/write_source_files/bar/BUILD.bazel
+++ b/write_source_files/bar/BUILD.bazel
@@ -9,6 +9,7 @@ proto_library(
     ],
 )
 
+# gazelle:exclude *.pb.go
 go_proto_library(
     name = "bar_go_protos",
     importpath = "aspect.build/bazel-examples/write_source_files/bar",

--- a/write_source_files/foo/BUILD.bazel
+++ b/write_source_files/foo/BUILD.bazel
@@ -9,6 +9,7 @@ proto_library(
     ],
 )
 
+# gazelle:exclude *.pb.go
 go_proto_library(
     name = "foo_go_protos",
     importpath = "aspect.build/bazel-examples/write_source_files/foo",


### PR DESCRIPTION
Otherwise our training courses trip over errors when running `configure`. We want to keep it green and no-changes-prompted.