### PR TITLE
fix: let Angular tests know where chrome is install on the AMI

### DIFF
--- a/.aspect/workflows/bazelrc
+++ b/.aspect/workflows/bazelrc
@@ -1,3 +1,6 @@
 # build without the bytes
 common --remote_download_outputs=minimal
 common --nobuild_runfile_links
+
+# let tests that require chrome know where it is installed
+common --test_env=CHROME_BIN=/usr/bin/chromium


### PR DESCRIPTION
Green up angular tests which don't know how to find chrome on the AMI
