### PR TITLE
Change lambda parameter to pass by value

### DIFF
--- a/speller/main/build-dictionary.cc
+++ b/speller/main/build-dictionary.cc
@@ -29,7 +29,7 @@ int main(int  /*argc*/, char ** /*argv*/) {
   Speller::LookupEngine engine("spell.db", true);
 
   for_each(common_words.begin(), common_words.end(),
-           [&](const string &word) { engine.AddEntry(word); });
+           [&](string word) { engine.AddEntry(word); });
 
   return 0;
 }


### PR DESCRIPTION
clang-tidy will flag as an unnecessary copy (performance-unnecessary-value-param)
