### PR TITLE
feat: upgrade rules_ruby and avoid building interpreter

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,23 +1,13 @@
 "Declare dependencies for bzlmod, see https://bazel.build/build/bzlmod"
 
 include("//tools:tools.MODULE.bazel")
-
 include("//tools:jvm.MODULE.bazel")
-
 include("//tools:python.MODULE.bazel")
-
 include("//tools:protobuf.MODULE.bazel")
-
 include("//tools:cpp.MODULE.bazel")
-
 include("//tools:containers.MODULE.bazel")
-
 include("//tools:nodejs.MODULE.bazel")
-
 include("//tools:rust.MODULE.bazel")
-
 include("//tools:swift.MODULE.bazel")
-
 include("//tools:go.MODULE.bazel")
-
 include("//tools:ruby.MODULE.bazel")

--- a/tools/ruby.MODULE.bazel
+++ b/tools/ruby.MODULE.bazel
@@ -3,11 +3,14 @@ Ruby support via rules_ruby
 https://github.com/bazel-contrib/rules_ruby
 """
 
-bazel_dep(name = "rules_ruby", version = "0.21.1")
+bazel_dep(name = "rules_ruby", version = "0.22.1")
 
 ruby = use_extension("@rules_ruby//ruby:extensions.bzl", "ruby")
 ruby.toolchain(
     name = "ruby",
+    # Skip compiling Ruby from source, use https://mise.jdx.dev/lang/ruby.html
+    # See https://github.com/bazel-contrib/rules_ruby/pull/340/changes
+    portable_ruby = True,
     version_file = "//:.ruby-version",
 )
 use_repo(ruby, "ruby", "ruby_toolchains")


### PR DESCRIPTION
This ought to work on the runner AMIs we had previously with fewer system libs.