### PR TITLE
feat: add lint aspects config and demo failing test

### DIFF
--- a/.aspect/cli/config.yaml
+++ b/.aspect/cli/config.yaml
@@ -2,3 +2,9 @@ plugins:
     - name: fix-visibility
       from: github.com/aspect-build/plugin-fix-visibility
       version: v0.1.0
+lint:
+  aspects:
+    - //tools/lint:linters.bzl%buf
+    - //tools/lint:linters.bzl%eslint
+    - //tools/lint:linters.bzl%vale
+    - //tools/lint:linters.bzl%tfsec

--- a/oci_python_image/hello_world/app_test.py
+++ b/oci_python_image/hello_world/app_test.py
@@ -5,6 +5,7 @@ def test_moo():
     app = Cow("John")
     app.say_hello()
 
+
 # Deliberately failing test to demonstrate test failure
 # # def test_name2():
 #     app = Cow("John")

--- a/oci_python_image/hello_world/app_test.py
+++ b/oci_python_image/hello_world/app_test.py
@@ -4,3 +4,8 @@ from hello_world.app import Cow
 def test_moo():
     app = Cow("John")
     app.say_hello()
+
+# Deliberately failing test to demonstrate test failure
+# # def test_name2():
+#     app = Cow("John")
+#     assert app.name == "James"


### PR DESCRIPTION
## Summary
- Wire up Aspect CLI lint aspects (buf, eslint, vale, tfsec) in `.aspect/cli/config.yaml`.
- Add commented-out deliberately-failing test in `oci_python_image/hello_world/app_test.py` to demo lint/test failure flow.

---

### Changes are visible to end-users: no

### Test plan

- [ ] `bazel run @aspect_cli//:cli -- lint //...` picks up configured aspects
- [ ] Existing `app_test` still passes (failing case is commented out)