### PR TITLE
fix: align GHA/GitLab/CircleCI on aspect-cli invocations

### DIFF
--- a/.aspect/cli/config.yaml
+++ b/.aspect/cli/config.yaml
@@ -2,9 +2,5 @@ plugins:
     - name: fix-visibility
       from: github.com/aspect-build/plugin-fix-visibility
       version: v0.1.0
-lint:
-  aspects:
-    - //tools/lint:linters.bzl%buf
-    - //tools/lint:linters.bzl%eslint
-    - //tools/lint:linters.bzl%vale
-    - //tools/lint:linters.bzl%tfsec
+# Lint aspects live in .aspect/config.axl (ctx.tasks["lint"].args.aspects).
+# Single source of truth so local + all CI invocations agree.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           command: rm -rf /workflows/artifacts
       - run:
           name: Buildifier
-          command: rosetta run buildifier
+          command: bazel run //:buildifier.check
       - store_artifacts:
           path: /workflows/artifacts
 
@@ -83,7 +83,7 @@ jobs:
           command: rm -rf /workflows/artifacts
       - run:
           name: Format
-          command: rosetta run format
+          command: aspect format
       - store_artifacts:
           path: /workflows/artifacts
   
@@ -109,7 +109,7 @@ jobs:
           command: rm -rf /workflows/artifacts
       - run:
           name: Gazelle
-          command: rosetta run gazelle
+          command: aspect gazelle --check
       - store_artifacts:
           path: /workflows/artifacts
   
@@ -135,7 +135,7 @@ jobs:
           command: rm -rf /workflows/artifacts
       - run:
           name: Lint
-          command: rosetta run lint
+          command: aspect lint //...
       - store_artifacts:
           path: /workflows/artifacts
 
@@ -161,7 +161,7 @@ jobs:
           command: rm -rf /workflows/artifacts /workflows/testlogs
       - run:
           name: Test
-          command: rosetta run test_0
+          command: aspect test --task-key=test_0 -- //... -//angular/... -//speller/...
       - store_test_results:
           path: /workflows/testlogs
       - store_artifacts:
@@ -190,7 +190,7 @@ jobs:
           name: Prepare archive directories
           command: rm -rf /workflows/artifacts /workflows/testlogs
       - run:
-          command: rosetta run test_1
+          command: aspect test --task-key=test_1 //angular/...
           name: Test (1)
       - store_test_results:
           path: /workflows/testlogs
@@ -220,11 +220,8 @@ jobs:
           name: Prepare archive directories
           command: rm -rf /workflows/artifacts /workflows/testlogs
       - run:
-          name: Delivery manifest
-          command: rosetta run delivery_manifest
-      - run:
           name: Delivery
-          command: rosetta run delivery
+          command: aspect delivery
       - store_artifacts:
           path: /workflows/artifacts
 

--- a/.github/workflows/aspect-workflows.yaml
+++ b/.github/workflows/aspect-workflows.yaml
@@ -32,7 +32,7 @@ jobs:
             - name: Prepare archive directories
               run: rm -rf /workflows/artifacts
             - name: Gazelle
-              run: rosetta run gazelle
+              run: aspect gazelle --check
             - name: Upload artifacts
               if: always()
               uses: actions/upload-artifact@v4
@@ -55,7 +55,7 @@ jobs:
             - name: Prepare archive directories
               run: rm -rf /workflows/artifacts
             - name: Buildifier
-              run: rosetta run buildifier
+              run: bazel run //:buildifier.check
             - name: Upload artifacts
               if: always()
               uses: actions/upload-artifact@v4
@@ -82,7 +82,7 @@ jobs:
             - name: Prepare archive directories
               run: rm -rf /workflows/artifacts
             - name: Lint
-              run: rosetta run lint
+              run: aspect lint //...
             - name: Upload artifacts
               if: always()
               uses: actions/upload-artifact@v4
@@ -107,7 +107,7 @@ jobs:
             - name: Prepare archive directories
               run: rm -rf /workflows/artifacts
             - name: Format
-              run: rosetta run format
+              run: aspect format
             - name: Upload artifacts
               if: always()
               uses: actions/upload-artifact@v4
@@ -130,7 +130,7 @@ jobs:
             - name: Prepare archive directories
               run: rm -rf /workflows/artifacts /workflows/testlogs
             - name: Test
-              run: rosetta run test_0
+              run: aspect test --task-key=test_0 -- //... -//angular/... -//speller/...
             - name: Upload artifacts
               if: always()
               uses: actions/upload-artifact@v4
@@ -155,7 +155,7 @@ jobs:
             - name: Prepare archive directories
               run: rm -rf /workflows/artifacts /workflows/testlogs
             - name: Test
-              run: rosetta run test_1
+              run: aspect test --task-key=test_1 //angular/...
             - name: Upload artifacts
               if: always()
               uses: actions/upload-artifact@v4
@@ -183,10 +183,8 @@ jobs:
               run: RUNNER_TRACKING_ID="" && /etc/aspect/workflows/bin/agent_health_check
             - name: Prepare archive directories
               run: rm -rf /workflows/artifacts
-            - name: Delivery manifest
-              run: rosetta run delivery_manifest
             - name: Delivery
-              run: rosetta run delivery
+              run: aspect delivery
             - name: Upload artifacts
               if: always()
               uses: actions/upload-artifact@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ test_0:
     - rm -rf /workflows/artifacts .workflows/artifacts && mkdir -p /workflows/artifacts .workflows && ln -s /workflows/artifacts .workflows/artifacts && rm -rf /workflows/testlogs .workflows/testlogs && mkdir -p /workflows/testlogs .workflows && ln -s /workflows/testlogs .workflows/testlogs
     - /etc/aspect/workflows/bin/gitlab_section_end "prepare_archive_directories"
     - /etc/aspect/workflows/bin/gitlab_section_start "test" "Test"
-    - rosetta run test_0
+    - aspect test --task-key=test_0 -- //... -//angular/... -//speller/...
     - /etc/aspect/workflows/bin/gitlab_section_end "test"
   tags:
     - aspect-workflows
@@ -44,7 +44,7 @@ test_1:
     - rm -rf /workflows/artifacts .workflows/artifacts && mkdir -p /workflows/artifacts .workflows && ln -s /workflows/artifacts .workflows/artifacts && rm -rf /workflows/testlogs .workflows/testlogs && mkdir -p /workflows/testlogs .workflows && ln -s /workflows/testlogs .workflows/testlogs
     - /etc/aspect/workflows/bin/gitlab_section_end "prepare_archive_directories"
     - /etc/aspect/workflows/bin/gitlab_section_start "test" "Test"
-    - rosetta run test_1
+    - aspect test --task-key=test_1 //angular/...
     - /etc/aspect/workflows/bin/gitlab_section_end "test"
   tags:
     - aspect-workflows
@@ -70,7 +70,7 @@ format:
     - rm -rf /workflows/artifacts .workflows/artifacts && mkdir -p /workflows/artifacts .workflows && ln -s /workflows/artifacts .workflows/artifacts
     - /etc/aspect/workflows/bin/gitlab_section_end "prepare_archive_directories"
     - /etc/aspect/workflows/bin/gitlab_section_start "format" "Format"
-    - rosetta run format
+    - aspect format
     - /etc/aspect/workflows/bin/gitlab_section_end "format"
   tags:
     - aspect-workflows
@@ -95,7 +95,7 @@ lint:
     - rm -rf /workflows/artifacts .workflows/artifacts && mkdir -p /workflows/artifacts .workflows && ln -s /workflows/artifacts .workflows/artifacts
     - /etc/aspect/workflows/bin/gitlab_section_end "prepare_archive_directories"
     - /etc/aspect/workflows/bin/gitlab_section_start "lint" "Lint"
-    - rosetta run lint
+    - aspect lint //...
     - /etc/aspect/workflows/bin/gitlab_section_end "lint"
   tags:
     - aspect-workflows
@@ -122,11 +122,8 @@ delivery:
     - /etc/aspect/workflows/bin/gitlab_section_start "prepare_archive_directories" "Prepare archive directories"
     - rm -rf /workflows/artifacts .workflows/artifacts && mkdir -p /workflows/artifacts .workflows && ln -s /workflows/artifacts .workflows/artifacts
     - /etc/aspect/workflows/bin/gitlab_section_end "prepare_archive_directories"
-    - /etc/aspect/workflows/bin/gitlab_section_start "delivery_manifest" "Delivery Manifest"
-    - rosetta run delivery_manifest
-    - /etc/aspect/workflows/bin/gitlab_section_end "delivery_manifest"
     - /etc/aspect/workflows/bin/gitlab_section_start "delivery" "Delivery"
-    - rosetta run delivery
+    - aspect delivery
     - /etc/aspect/workflows/bin/gitlab_section_end "delivery"
   tags:
     - aspect-workflows

--- a/tools/tools.lock.json
+++ b/tools/tools.lock.json
@@ -4,15 +4,15 @@
     "binaries": [
       {
         "kind": "file",
-        "url": "https://github.com/aspect-build/aspect-cli/releases/download/v2025.51.3/aspect-cli-x86_64-unknown-linux-musl",
-        "sha256": "88300e77d2110ef56f4f4a369f0832974828cce779ecf843003a91b5bf79488f",
+        "url": "https://github.com/aspect-build/aspect-cli/releases/download/v2026.18.39/aspect-cli-x86_64-unknown-linux-musl",
+        "sha256": "506c2f3af4f4e8c475631642f522757cce920a6fa56b1dbac8772cd59d58ad4a",
         "os": "linux",
         "cpu": "x86_64"
       },
       {
         "kind": "file",
-        "url": "https://github.com/aspect-build/aspect-cli/releases/download/v2025.51.3/aspect-cli-aarch64-apple-darwin",
-        "sha256": "216ff41aed33e6f264ea1360d50effe88b8b4130006b0c12db9a2602e619da7b",
+        "url": "https://github.com/aspect-build/aspect-cli/releases/download/v2026.18.39/aspect-cli-aarch64-apple-darwin",
+        "sha256": "d6b01f3fd1fd88248ba86f09536ce630e6ef3d8fca47599740beb03c992d99d3",
         "os": "macos",
         "cpu": "arm64"
       }


### PR DESCRIPTION
## Summary
- Buildkite migrated to `aspect <task>` in #549, but GHA/GitLab/CircleCI still ran `rosetta run <task>`. Same commit therefore exercised two different code paths: Buildkite read `.aspect/config.axl`, the rest read `.aspect/cli/config.yaml` `lint.aspects[]`. PR #551 re-added that block with `vale` + `tfsec` (undefined in `tools/lint/linters.bzl`); Buildkite ignored the block, synced repos failed with `vale is not exported from //tools/lint:linters.bzl`.
- Migrate the three lagging CIs to the same `aspect` invocations Buildkite uses so platform divergence surfaces pre-merge.
- Drop the dead `lint.aspects[]` block from `.aspect/cli/config.yaml`; `.aspect/config.axl` is now the single source of truth.
- Bump aspect-cli in `tools/tools.lock.json` v2025.51.3 → v2026.18.39 so the multitool binary matches `.aspect/version.axl`.

Mapping applied across `.github/workflows/aspect-workflows.yaml`, `.gitlab-ci.yml`, `.circleci/config.yml`:

| rosetta | aspect-cli |
|---|---|
| `rosetta run gazelle` | `aspect gazelle --check` |
| `rosetta run buildifier` | `bazel run //:buildifier.check` |
| `rosetta run lint` | `aspect lint //...` |
| `rosetta run format` | `aspect format` |
| `rosetta run test_0` | `aspect test --task-key=test_0 -- //... -//angular/... -//speller/...` |
| `rosetta run test_1` | `aspect test --task-key=test_1 //angular/...` |
| `rosetta run delivery_manifest` + `rosetta run delivery` | `aspect delivery` |

`warming` jobs left on rosetta — no Buildkite migration reference yet.

## Test plan
- [ ] GitHub Actions: `Aspect Workflows` workflow passes on this branch (gazelle / buildifier / lint / format / test_0 / test_1).
- [ ] After merge to main: sync mirrors push to `bazel-examples-gha` and `bazel-examples-gl`; verify both pipelines pass on the merge SHA.
- [ ] Buildkite (`aspect-build/bazel-examples`) still passes — invocation unchanged.
- [ ] CircleCI dry-check: `circleci config validate .circleci/config.yml` if available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)