### PR TITLE
fix: read full line for each client message in JavaLoggingClient

### DIFF
--- a/logger/client/src/build/aspect/JavaLoggingClient.java
+++ b/logger/client/src/build/aspect/JavaLoggingClient.java
@@ -13,7 +13,7 @@ public class JavaLoggingClient {
     String message = scanner.nextLine();
     while (!message.equals("exit")) {
       client.sendLogMessageToServer(message);
-      message = scanner.next();
+      message = scanner.nextLine();
     }
     client.shutdown();
   }


### PR DESCRIPTION
## Summary

The interactive loop in `JavaLoggingClient` (`logger/client/src/build/aspect/JavaLoggingClient.java`) called `scanner.next()` on every iteration after the initial `scanner.nextLine()`. `Scanner.next()` reads only a single whitespace-delimited token, so any message containing a space was split into one send per word. The first message worked correctly because it was read with `nextLine()`; every subsequent message was tokenized.

Switching the in-loop read to `scanner.nextLine()` makes the behavior consistent and captures the entire line as a single message.

## Reproduction

```
Enter log messages to send to the server, enter 'exit' to stop the client.
hello world
May 15, 2026 2:51:06 PM build.aspect.JavaLoggingClientLibrary sendLogMessageToServer
INFO: Trying to send message 'hello world' to server...
other message
May 15, 2026 2:51:36 PM build.aspect.JavaLoggingClientLibrary sendLogMessageToServer
INFO: Trying to send message 'other' to server...
May 15, 2026 2:51:36 PM build.aspect.JavaLoggingClientLibrary sendLogMessageToServer
INFO: Trying to send message 'message' to server...
```

Note the second input `other message` was sent as two separate messages (`other`, then `message`).