### PR TITLE
ci: adopt aspect-build/setup-aspect across Aspect Workflows jobs

### DIFF
--- a/.github/workflows/ci-github-runners.yaml
+++ b/.github/workflows/ci-github-runners.yaml
@@ -15,10 +15,6 @@ on:
 permissions:
     id-token: write
 
-env:
-    ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
-    ASPECT_LAUNCHER_VERSION: 2026.22.39
-
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
     cancel-in-progress: true
@@ -30,76 +26,51 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+            - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
               with:
-                bazelisk-cache: true
-                disk-cache: ${{ github.workflow }}-test
-                repository-cache: true
-                external-cache: true
+                aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
-              run: |
-                curl -fsSL https://install.aspect.build | bash -s -- "$ASPECT_LAUNCHER_VERSION"
-                aspect test --task-key=test-gha-ephemeral -- //...
+              run: aspect test --task-key=test-gha-ephemeral -- //...
 
     gazelle:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+            - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
               with:
-                bazelisk-cache: true
-                disk-cache: ${{ github.workflow }}-gazelle
-                repository-cache: true
-                external-cache: true
+                aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Gazelle
-              run: |
-                curl -fsSL https://install.aspect.build | bash -s -- "$ASPECT_LAUNCHER_VERSION"
-                aspect gazelle --task-key=gazelle-gha-ephemeral
+              run: aspect gazelle --task-key=gazelle-gha-ephemeral
 
     format:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+            - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
               with:
-                bazelisk-cache: true
-                disk-cache: ${{ github.workflow }}-format
-                repository-cache: true
-                external-cache: true
+                aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Format
-              run: |
-                curl -fsSL https://install.aspect.build | bash -s -- "$ASPECT_LAUNCHER_VERSION"
-                aspect format --task-key=format-gha-ephemeral
+              run: aspect format --task-key=format-gha-ephemeral
 
     buildifier:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+            - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
               with:
-                bazelisk-cache: true
-                disk-cache: ${{ github.workflow }}-buildifier
-                repository-cache: true
-                external-cache: true
+                aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Buildifier
-              run: |
-                curl -fsSL https://install.aspect.build | bash -s -- "$ASPECT_LAUNCHER_VERSION"
-                aspect buildifier --task-key=buildifier-gha-ephemeral
+              run: aspect buildifier --task-key=buildifier-gha-ephemeral
 
     lint:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+            - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
               with:
-                bazelisk-cache: true
-                disk-cache: ${{ github.workflow }}-lint
-                repository-cache: true
-                external-cache: true
+                aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Lint
-              run: |
-                curl -fsSL https://install.aspect.build | bash -s -- "$ASPECT_LAUNCHER_VERSION"
-                aspect lint --task-key=lint-gha-ephemeral -- //...
+              run: aspect lint --task-key=lint-gha-ephemeral -- //...
 
 
     delivery:
@@ -109,15 +80,11 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+            - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
               with:
-                bazelisk-cache: true
-                disk-cache: ${{ github.workflow }}-delivery
-                repository-cache: true
-                external-cache: true
+                aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Delivery
               run: |
-                curl -fsSL https://install.aspect.build | bash -s -- "$ASPECT_LAUNCHER_VERSION"
                 # We pass --track-state=false --mode=always to disable selective delivery which is currently
                 # only supported on Aspect Workflows CI runners as it requires a backend service
                 aspect delivery --task-key=delivery-gha-ephemeral --track-state=false --mode=always

--- a/.github/workflows/ci-workflows-runners.yaml
+++ b/.github/workflows/ci-workflows-runners.yaml
@@ -15,9 +15,6 @@ on:
 permissions:
     id-token: write
 
-env:
-    ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
-
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
     cancel-in-progress: true
@@ -29,6 +26,9 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
+            - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+              with:
+                aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
               run: aspect test --task-key=test-gha -- //...
 
@@ -36,6 +36,9 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
+            - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+              with:
+                aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Gazelle
               run: aspect gazelle --task-key=gazelle-gha
 
@@ -43,6 +46,9 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
+            - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+              with:
+                aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Format
               run: aspect format --task-key=format-gha
 
@@ -50,6 +56,9 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
+            - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+              with:
+                aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Buildifier
               run: aspect buildifier --task-key=buildifier-gha
 
@@ -57,6 +66,9 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
+            - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+              with:
+                aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Lint
               run: aspect lint --task-key=lint-gha -- //...
 
@@ -68,5 +80,8 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
+            - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+              with:
+                aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Delivery
               run: aspect delivery --task-key=delivery-gha


### PR DESCRIPTION
Swap the manual `curl install.aspect.build | bash` + `bazel-contrib/setup-bazel` combination (on ephemeral GitHub runners) and the bare `aspect` invocations (on Aspect Workflows runners) for the new [`aspect-build/setup-aspect`](https://github.com/aspect-build/setup-aspect) action. bazel-examples is the premier downstream showcase for Aspect Workflows + AXL task usage, so it now models the recommended setup.

`setup-aspect` handles:

- Launcher install + Bazelisk install (skipped automatically when `bazel` is already on PATH, e.g. on Workflows runners).
- `bazelisk-cache` / `disk-cache` / `repository-cache` wiring via `@actions/cache` on ephemeral runners. All three default to `true` in setup-aspect, so each ephemeral job's `with:` block now carries only `aspect-api-token`. The six ephemeral jobs share one default disk cache (no per-job segregation key) — they target the same workspace with the same default Bazel config, so cross-job cache hits offset the one-time save-race on first run.
- Stdin-fed `aspect auth login --with-api-token` to exchange the long-lived `ASPECT_API_TOKEN` for a short-lived JWT, persisting only the JWT — the raw token no longer leaks into every step's `env`.
- On Aspect Workflows runners, `rosetta bazelrc > /etc/bazel.bazelrc` so raw `bazel` calls outside of `aspect <task>` also benefit from the runner's cache wiring.

`ci-vanilla-bazel.yaml` is intentionally left alone — it exists as the comparison example for raw `bazel` CI without aspect.

`setup-aspect` is pinned to commit SHA `c22a8f64fb38f82f59ce809cd7eb9f8ae096da44` with the `# v2026.23.2` tag suffix, matching [the action's v2026.23.2 release](https://github.com/aspect-build/setup-aspect/releases/tag/v2026.23.2).

### Changes are visible to end-users: no

### Test plan

- Watch the CI runs that this PR triggers ("CI - Aspect Workflows (Github runners)" + "CI - Aspect Workflows (Workflows runners)"). Both cover every modified job.
