### PR TITLE
Update routine dependencies

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,13 @@ common --modify_execution_info=GemInstall=+no-remote-exec,BundleInstall=+no-remo
 # We have a lot of dependencies and are okay with some of them bringing a newer version via a transitive dep.
 common --check_direct_dependencies=off
 
+# Set a macOS deployment target so C++ that uses std::filesystem (introduced in
+# macOS 10.15) compiles under the hermetic LLVM toolchain. toolchains_llvm 1.8+
+# no longer defaults a minimum OS version, so without this `speller/` fails to
+# build on macOS with "'path' is unavailable: introduced in macOS 10.15".
+# Inert on non-Apple builds (Linux CI), so safe to set unconditionally.
+common --macos_minimum_os=10.15
+
 # 'bazel build --config=lint' will produce the linter reports.
 # `aspect lint` (via aspect_rules_lint's lint.axl task) reuses this config.
 common:lint --aspects=//tools/lint:linters.bzl%buf

--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,13 @@ common --modify_execution_info=GemInstall=+no-remote-exec,BundleInstall=+no-remo
 # We have a lot of dependencies and are okay with some of them bringing a newer version via a transitive dep.
 common --check_direct_dependencies=off
 
+# Override the preset's `--lockfile_mode=error` on CI. MODULE.bazel.lock is
+# .gitignored here, so CI has no committed lock — it restores one from the
+# Aspect Workflows warming archive (regenerated nightly). `error` mode breaks any
+# PR that bumps deps the warming archive hasn't picked up yet; `off` lets CI
+# resolve the new versions directly. Imported preset runs first, so this wins.
+common:ci --lockfile_mode=off
+
 # Set a macOS deployment target so C++ that uses std::filesystem (introduced in
 # macOS 10.15) compiles under the hermetic LLVM toolchain. toolchains_llvm 1.8+
 # no longer defaults a minimum OS version, so without this `speller/` fails to

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aspect-build/bazel-examples
 
-go 1.24.13
+go 1.24.5
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20251209175733-2a1774d88802.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aspect-build/bazel-examples
 
-go 1.24.5
+go 1.24.13
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20251209175733-2a1774d88802.1

--- a/tools/cpp.MODULE.bazel
+++ b/tools/cpp.MODULE.bazel
@@ -4,10 +4,10 @@ Hermetic C++ toolchain, to relieve the dependency on a locally installed CC etc.
 
 # keep-sorted start
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
-bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "rules_cc", version = "0.2.19")
 bazel_dep(name = "rules_foreign_cc", version = "0.15.1")  # Bazel 9 compat
-bazel_dep(name = "sqlite3", version = "3.51.2.bcr.1")  # C code for SQLite.
-bazel_dep(name = "toolchains_llvm", version = "1.7.0")
+bazel_dep(name = "sqlite3", version = "3.53.2")  # C code for SQLite.
+bazel_dep(name = "toolchains_llvm", version = "1.8.0")
 # keep-sorted end
 
 #########################

--- a/tools/go.MODULE.bazel
+++ b/tools/go.MODULE.bazel
@@ -3,12 +3,13 @@ Go
 See https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/bzlmod.md
 """
 
-bazel_dep(name = "rules_go", version = "0.60.0")
+bazel_dep(name = "rules_go", version = "0.61.1")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
     name = "go_sdk",
-    version = "1.24.5",
+    # >= 1.24.12 required by gazelle 0.51.x's go.work (its repository tools).
+    version = "1.24.13",
 )
 use_repo(go_sdk, "go_sdk")
 

--- a/tools/go.MODULE.bazel
+++ b/tools/go.MODULE.bazel
@@ -3,13 +3,15 @@ Go
 See https://github.com/bazelbuild/rules_go/blob/master/docs/go/core/bzlmod.md
 """
 
-bazel_dep(name = "rules_go", version = "0.61.1")
+# Held at 0.60.0: rules_go 0.61.1 floors gazelle at 0.51.3, which (with the
+# protobuf 33.0 pin) breaks //protobuf and also requires Go SDK >= 1.24.12.
+# Bump alongside gazelle + the protobuf cluster.
+bazel_dep(name = "rules_go", version = "0.60.0")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
     name = "go_sdk",
-    # >= 1.24.12 required by gazelle 0.51.x's go.work (its repository tools).
-    version = "1.24.13",
+    version = "1.24.5",
 )
 use_repo(go_sdk, "go_sdk")
 

--- a/tools/preset.bazelrc
+++ b/tools/preset.bazelrc
@@ -81,13 +81,6 @@ common:ci --grpc_keepalive_time="30s"
 common --heap_dump_on_oom
 # Docs: https://registry.build/flag/bazel@9.0.0?filter=heap_dump_on_oom
 
-# Allow the Bazel server to check directory sources for changes. Ensures that the Bazel server
-# notices when a directory changes, if you have a directory listed in the srcs of some target.
-# Recommended when using [copy_directory](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/copy_directory.md)
-# and [rules_js](https://github.com/aspect-build/rules_js) since npm package are source directories inputs to copy_directory actions.
-startup --host_jvm_args="-DBAZEL_TRACK_SOURCE_DIRECTORIES=1"
-# Docs: https://registry.build/flag/bazel@9.0.0?filter=host_jvm_args
-
 # By default, Bazel automatically creates __init__.py files for py_binary and py_test targets.
 # From https://github.com/bazelbuild/bazel/issues/10076:
 # > It is magic at a distance.
@@ -96,12 +89,20 @@ startup --host_jvm_args="-DBAZEL_TRACK_SOURCE_DIRECTORIES=1"
 common --incompatible_default_to_explicit_init_py
 # Docs: https://registry.build/flag/bazel@9.0.0?filter=incompatible_default_to_explicit_init_py
 
-# Make builds more reproducible by using a static value for PATH and not inheriting LD_LIBRARY_PATH.
-# Use `--action_env=ENV_VARIABLE` if you want to inherit specific variables from the environment where Bazel runs.
-# Note that doing so can prevent cross-user caching if a shared cache is used.
-# See https://github.com/bazelbuild/bazel/issues/2574 for more details.
-common --incompatible_strict_action_env
-# Docs: https://registry.build/flag/bazel@9.0.0?filter=incompatible_strict_action_env
+# Fail if Starlark files are not UTF-8 encoded.
+# Introduced in Bazel 8.1, see https://github.com/bazelbuild/bazel/pull/24944
+# Recommended to enable since Bazel 8.5, see https://github.com/bazel-contrib/bazelrc-preset.bzl/issues/95
+common --incompatible_enforce_starlark_utf8="error"
+# Docs: https://registry.build/flag/bazel@9.0.0?filter=incompatible_enforce_starlark_utf8
+
+# Accept multiple --modify_execution_info flags, rather than the last flag overwriting earlier ones.
+common --incompatible_modify_execution_info_additive
+# Docs: https://registry.build/flag/bazel@9.0.0?filter=incompatible_modify_execution_info_additive
+
+# Fail the build if the MODULE.bazel.lock file is out of date.
+# Using this mode in ci prevents the lockfile from being out of date.
+common:ci --lockfile_mode="error"
+# Docs: https://registry.build/flag/bazel@9.0.0?filter=lockfile_mode
 
 # Add the CloudFlare mirror of BCR-referenced downloads.
 # Improves reliability of Bazel when CDNs are flaky, for example issues with ftp.gnu.org in 2025.

--- a/tools/python.MODULE.bazel
+++ b/tools/python.MODULE.bazel
@@ -11,11 +11,11 @@ ecosystem.
 
 # keep-sorted start
 bazel_dep(name = "aspect_rules_py", version = "1.3.1")
-bazel_dep(name = "bazel_features", version = "1.21.0")
+bazel_dep(name = "bazel_features", version = "1.49.0")
 bazel_dep(name = "rules_mypy", version = "0.41.0")
 bazel_dep(name = "rules_python", version = "1.1.0")
 bazel_dep(name = "rules_python_gazelle_plugin", version = "1.1.0")
-bazel_dep(name = "rules_uv", version = "0.25.0")
+bazel_dep(name = "rules_uv", version = "0.89.2")
 # keep-sorted end
 
 # rules_mypy v0.41.0 not yet published to BCR; pin to upstream GitHub release

--- a/tools/tools.MODULE.bazel
+++ b/tools/tools.MODULE.bazel
@@ -1,22 +1,22 @@
 # keep-sorted start
-bazel_dep(name = "aspect_bazel_lib", version = "2.20.4", repo_name = None)
+bazel_dep(name = "aspect_bazel_lib", version = "2.22.5", repo_name = None)
 bazel_dep(name = "aspect_gazelle_prebuilt", version = "0.0.21")
-bazel_dep(name = "aspect_rules_lint", version = "2.0.0")
-bazel_dep(name = "bazel_env.bzl", version = "0.2.0")
-bazel_dep(name = "bazel_lib", version = "3.0.0")
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "bazelrc-preset.bzl", version = "1.5.0")
+bazel_dep(name = "aspect_rules_lint", version = "2.7.1")
+bazel_dep(name = "bazel_env.bzl", version = "0.7.2")
+bazel_dep(name = "bazel_lib", version = "3.3.1")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.9.2")
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0")
-bazel_dep(name = "gazelle", version = "0.45.0")
-bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "rules_multitool", version = "1.3.0")
-bazel_dep(name = "rules_shell", version = "0.4.1")
-bazel_dep(name = "tar.bzl", version = "0.7.0")
+bazel_dep(name = "gazelle", version = "0.51.3")
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_multitool", version = "1.11.1")
+bazel_dep(name = "rules_shell", version = "0.8.0")
+bazel_dep(name = "tar.bzl", version = "0.10.5")
 # keep-sorted end
 
 single_version_override(
     module_name = "aspect_bazel_lib",
-    version = "2.20.4",
+    version = "2.22.5",
 )
 
 #########################

--- a/tools/tools.MODULE.bazel
+++ b/tools/tools.MODULE.bazel
@@ -1,13 +1,23 @@
 # keep-sorted start
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.5", repo_name = None)
 bazel_dep(name = "aspect_gazelle_prebuilt", version = "0.0.21")
-bazel_dep(name = "aspect_rules_lint", version = "2.7.1")
+
+# Held at 2.0.0: 2.7.1 dropped lint/clippy.bzl (Rust linting moved to the separate
+# aspect_rules_lint_rust module) — //tools/lint:linters.bzl would need rewiring —
+# and raises its protobuf floor to 33.4, colliding with the protobuf 33.0 pin.
+# Bump it in its own PR (add aspect_rules_lint_rust, rewire clippy).
+bazel_dep(name = "aspect_rules_lint", version = "2.0.0")
 bazel_dep(name = "bazel_env.bzl", version = "0.7.2")
 bazel_dep(name = "bazel_lib", version = "3.3.1")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "bazelrc-preset.bzl", version = "1.9.2")
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0")
-bazel_dep(name = "gazelle", version = "0.51.3")
+
+# Held at 0.45.0: gazelle 0.51's proto language emits
+# `load("@com_google_protobuf//bazel:proto_library.bzl")` in generated BUILDs
+# (e.g. @buf_deps), but the protobuf 33.0 pin (for toolchains_protoc 0.6.1) has no
+# `bazel` package there, breaking //protobuf. Bump with the protobuf cluster.
+bazel_dep(name = "gazelle", version = "0.45.0")
 bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "rules_multitool", version = "1.11.1")
 bazel_dep(name = "rules_shell", version = "0.8.0")


### PR DESCRIPTION
Bumps the **routine, low-risk** dependency set — §2 of the cleanup plan. Several bumps turned out to be entangled (protobuf-pin / clippy-module / gazelle-proto interactions) and are deferred to dedicated PRs.

## Bumped (this PR)

- **tools**: `aspect_bazel_lib` 2.20.4→2.22.5, `bazel_env.bzl` 0.2.0→0.7.2, `bazel_lib` 3.0→3.3.1, `bazel_skylib` 1.7.1→1.9.0, `bazelrc-preset.bzl` 1.5→1.9.2 (regenerated `tools/preset.bazelrc`), `platforms` 0.0.10→1.1.0, `rules_multitool` 1.3→1.11.1, `rules_shell` 0.4.1→0.8.0, `tar.bzl` 0.7→0.10.5.
- **cpp**: `rules_cc` 0.1.1→0.2.19, `sqlite3` →3.53.2, `toolchains_llvm` 1.7→1.8.0.
- **python**: `bazel_features` 1.21→1.49.0, `rules_uv` 0.25→0.89.2.

## Fixes the bumps required

- **`--macos_minimum_os=10.15`** (`.bazelrc`) — `toolchains_llvm` 1.8 dropped its default min-OS, breaking `speller/`'s `std::filesystem` on macOS. Inert on Linux CI.
- **`--lockfile_mode=off` on CI** (`.bazelrc`) — `bazelrc-preset.bzl` 1.9.2 newly introduced `common:ci --lockfile_mode=error`, which main never had. The lockfile is `.gitignored`.

## Held back — entangled, deferred to their own PRs

- **`gazelle` (0.45.0)** & **`rules_go` (0.60.0)**: rules_go 0.61.1 floors gazelle at 0.51.3; gazelle 0.51's proto language emits `@com_google_protobuf//bazel:proto_library.bzl` loads that the **protobuf 33.0 pin** (for toolchains_protoc 0.6.1) can't satisfy → `//protobuf` fails. Also needs Go SDK ≥1.24.12. → goes with the **protobuf cluster**.
- **`aspect_rules_lint` (2.0.0)**: 2.7.1 dropped `lint/clippy.bzl` (Rust linting moved to a separate `aspect_rules_lint_rust` module) and raises its protobuf floor to 33.4. → its own PR (add `aspect_rules_lint_rust`, rewire clippy).
- **container_structure_test (1.19.1)**, the **protobuf/JVM/nodejs/swift clusters**, **buildifier 8**, **rules_python/rules_py 2.x**, and **Bazel 9.1.1** — deferred per the plan.

---

### Changes are visible to end-users: no
- Breaking change: no

### Test plan

- Local: `bazel build //...`, `bazel test //... --test_tag_filters=-no-aw` (32 tests), `aspect gazelle --check`, `aspect buildifier`, `aspect lint`, `aspect format` — all green, including `//protobuf/...`.
- CI green across providers (watching).
