### PR TITLE
Add Aspect Workflows Buildkite plugin + bump setup-aspect to v2026.25.1

### DIFF
--- a/.buildkite/buildkite.yaml
+++ b/.buildkite/buildkite.yaml
@@ -4,7 +4,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/aspect-workflows#19a9eb187ad1f1c65c1b6d64a7fc03589041c8ae: ~ # v2026.25.0
+    - aspect-build/aspect-workflows#61d7547edd007a6d6a5d1e4972bf2b84b4f08faf: ~ # v2026.25.1
   retry:
     manual:
       allowed: true
@@ -23,7 +23,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/aspect-workflows#19a9eb187ad1f1c65c1b6d64a7fc03589041c8ae: ~ # v2026.25.0
+    - aspect-build/aspect-workflows#61d7547edd007a6d6a5d1e4972bf2b84b4f08faf: ~ # v2026.25.1
   retry:
     manual:
       allowed: true
@@ -42,7 +42,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/aspect-workflows#19a9eb187ad1f1c65c1b6d64a7fc03589041c8ae: ~ # v2026.25.0
+    - aspect-build/aspect-workflows#61d7547edd007a6d6a5d1e4972bf2b84b4f08faf: ~ # v2026.25.1
   retry:
     manual:
       allowed: true
@@ -61,7 +61,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/aspect-workflows#19a9eb187ad1f1c65c1b6d64a7fc03589041c8ae: ~ # v2026.25.0
+    - aspect-build/aspect-workflows#61d7547edd007a6d6a5d1e4972bf2b84b4f08faf: ~ # v2026.25.1
   retry:
     manual:
       allowed: true
@@ -80,7 +80,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/aspect-workflows#19a9eb187ad1f1c65c1b6d64a7fc03589041c8ae: ~ # v2026.25.0
+    - aspect-build/aspect-workflows#61d7547edd007a6d6a5d1e4972bf2b84b4f08faf: ~ # v2026.25.1
   retry:
     manual:
       allowed: true
@@ -99,7 +99,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/aspect-workflows#19a9eb187ad1f1c65c1b6d64a7fc03589041c8ae: ~ # v2026.25.0
+    - aspect-build/aspect-workflows#61d7547edd007a6d6a5d1e4972bf2b84b4f08faf: ~ # v2026.25.1
   retry:
     manual:
       allowed: true

--- a/.buildkite/buildkite.yaml
+++ b/.buildkite/buildkite.yaml
@@ -3,6 +3,8 @@ steps:
   label: ":bazel: Test"
   agents:
     queue: aspect-default
+  plugins:
+    - aspect-build/aspect-workflows#19a9eb187ad1f1c65c1b6d64a7fc03589041c8ae: ~ # v2026.25.0
   retry:
     manual:
       allowed: true
@@ -20,6 +22,8 @@ steps:
   label: ":hammer_and_wrench: Buildifier"
   agents:
     queue: aspect-default
+  plugins:
+    - aspect-build/aspect-workflows#19a9eb187ad1f1c65c1b6d64a7fc03589041c8ae: ~ # v2026.25.0
   retry:
     manual:
       allowed: true
@@ -37,6 +41,8 @@ steps:
   label: ":hammer_and_wrench: Format"
   agents:
     queue: aspect-default
+  plugins:
+    - aspect-build/aspect-workflows#19a9eb187ad1f1c65c1b6d64a7fc03589041c8ae: ~ # v2026.25.0
   retry:
     manual:
       allowed: true
@@ -54,6 +60,8 @@ steps:
   label: ":deer: Gazelle"
   agents:
     queue: aspect-default
+  plugins:
+    - aspect-build/aspect-workflows#19a9eb187ad1f1c65c1b6d64a7fc03589041c8ae: ~ # v2026.25.0
   retry:
     manual:
       allowed: true
@@ -71,6 +79,8 @@ steps:
   label: ":broom: Lint"
   agents:
     queue: aspect-default
+  plugins:
+    - aspect-build/aspect-workflows#19a9eb187ad1f1c65c1b6d64a7fc03589041c8ae: ~ # v2026.25.0
   retry:
     manual:
       allowed: true
@@ -88,6 +98,8 @@ steps:
   label: ":bazel: Delivery"
   agents:
     queue: aspect-default
+  plugins:
+    - aspect-build/aspect-workflows#19a9eb187ad1f1c65c1b6d64a7fc03589041c8ae: ~ # v2026.25.0
   retry:
     manual:
       allowed: true

--- a/.github/workflows/ci-github-runners.yaml
+++ b/.github/workflows/ci-github-runners.yaml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
@@ -36,7 +36,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Gazelle
@@ -46,7 +46,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Format
@@ -56,7 +56,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Buildifier
@@ -66,7 +66,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Lint
@@ -80,7 +80,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Delivery

--- a/.github/workflows/ci-workflows-runners.yaml
+++ b/.github/workflows/ci-workflows-runners.yaml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
@@ -36,7 +36,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Gazelle
@@ -46,7 +46,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Format
@@ -56,7 +56,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Buildifier
@@ -66,7 +66,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Lint
@@ -80,7 +80,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@36c688a9bbb0c84d55d7eca31bf3215e9d265bff # v2026.24.1
+            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Delivery


### PR DESCRIPTION
Adds the new Aspect Workflows tooling across both CI surfaces in this repo, pinned to the latest releases:

- **Buildkite** (`.buildkite/buildkite.yaml`): adds the [`aspect-build/aspect-workflows`](https://github.com/aspect-build/aspect-workflows-buildkite-plugin) plugin (`v2026.25.1`) to every step. The plugin's `pre-command` hook waits for the runner's cache warming to complete and generates `/etc/bazel.bazelrc` via `rosetta`, so any raw `bazel` call routes through the runner's caching infrastructure.
- **GitHub Actions** (`ci-github-runners.yaml`, `ci-workflows-runners.yaml`): bumps `aspect-build/setup-aspect` to `v2026.25.1`.

`v2026.25.1` of both tools includes the fix to fail fast with an actionable message when a repo has no `.bazelversion` before `rosetta bazelrc`, plus (for the plugin) running in the `pre-command` hook so `rosetta` runs after checkout. Verified working on the warming pipeline.

The existing steps all run `aspect <task>`, which already self-configures, so the plugin is largely a no-op-beyond-aspect here — this primarily confirms the tooling loads and runs cleanly on the real `aspect-default` runners.

### Changes are visible to end-users: no

### Test plan

- Buildkite and GitHub Actions CI for this PR exercise the plugin / action on the real Aspect Workflows runners.
- Local: `yq`/`actionlint` validate the workflow YAML; plugin verified end-to-end on the warming pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
