### PR TITLE
Add Aspect Workflows CircleCI orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aspect-workflows: aspect-build/aspect-workflows@2026.25.1
+  aspect-workflows: aspect-build/aspect-workflows@2026.25.2
 
 workflows:
   aspect-workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aspect-workflows: aspect-build/aspect-workflows@2026.25.2
+  aspect-workflows: aspect-build/aspect-workflows@2026.25.3
 
 workflows:
   aspect-workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  aspect-workflows: aspect-build/aspect-workflows@2026.25.1
+
 workflows:
   aspect-workflows:
     jobs:
@@ -35,6 +38,7 @@ jobs:
     working_directory: /mnt/ephemeral/workdir
     steps:
       - checkout
+      - aspect-workflows/setup
       - run:
           name: Test
           command: aspect test --task-key=test-cci -- //...
@@ -45,6 +49,7 @@ jobs:
     working_directory: /mnt/ephemeral/workdir
     steps:
       - checkout
+      - aspect-workflows/setup
       - run:
           name: Buildifier
           command: aspect buildifier --task-key=buildifier-cci
@@ -55,6 +60,7 @@ jobs:
     working_directory: /mnt/ephemeral/workdir
     steps:
       - checkout
+      - aspect-workflows/setup
       - run:
           name: Format
           command: aspect format --task-key=format-cci
@@ -65,6 +71,7 @@ jobs:
     working_directory: /mnt/ephemeral/workdir
     steps:
       - checkout
+      - aspect-workflows/setup
       - run:
           name: Gazelle
           command: aspect gazelle --task-key=gazelle-cci
@@ -75,6 +82,7 @@ jobs:
     working_directory: /mnt/ephemeral/workdir
     steps:
       - checkout
+      - aspect-workflows/setup
       - run:
           name: Lint
           command: aspect lint  --task-key=lint-cci -- //...
@@ -85,6 +93,7 @@ jobs:
     working_directory: /mnt/ephemeral/workdir
     steps:
       - checkout
+      - aspect-workflows/setup
       - run:
           name: Delivery
           command: aspect delivery --task-key=delivery-cci


### PR DESCRIPTION
Add the new [Aspect Workflows CircleCI orb](https://github.com/aspect-build/aspect-workflows-circleci-orb) (`aspect-build/aspect-workflows@2026.25.1`) by adding its `setup` command to every CircleCI task job (test, buildifier, format, gazelle, lint, delivery).

The orb's `setup` command waits for the runner's cache warming to complete and writes the Workflows-tuned `/etc/bazel.bazelrc` via `rosetta`, so any raw `bazel` call routes through the runner's remote cache, BES backend, and NVMe disk cache. It's the CircleCI counterpart of `setup-aspect` (GitHub Actions) and the Buildkite plugin.

These jobs all run `aspect <task>`, which already self-configures, so the orb is largely a no-op-beyond-aspect here — this primarily confirms the orb loads and runs cleanly on the real `aspect-build/aspect-default` CircleCI runners. The `warming` job (infrastructure, not an `aspect <task>` job) is left unchanged.

### Changes are visible to end-users: no

### Test plan

- `circleci config validate` passes against the published orb (resolves `aspect-build/aspect-workflows@2026.25.1` and the `setup` command).
- This PR's CircleCI run exercises the orb on the real runners — confirm each job's log shows the orb's "Aspect Workflows: configure bazel" step (runner metadata, warming wait, `/etc/bazel.bazelrc` write) before the `aspect` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
