### PR TITLE
Adopt the Aspect Workflows GitLab component; simplify warming jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,10 +109,8 @@ jobs:
     resource_class: aspect-build/aspect-default
     working_directory: /mnt/ephemeral/workdir
     steps:
-      - run:
-          name: Workflows environment
-          command: /etc/aspect/workflows/bin/configure_workflows_env
       - checkout
+      - aspect-workflows/setup
       # we still need a .aspect/workflows/config.yaml until the AXL warming task is ready
       - run:
           name: Create legacy workflows config
@@ -122,9 +120,6 @@ jobs:
             tasks:
               - warming:
             EOF
-      - run:
-          name: Agent health check
-          command: /etc/aspect/workflows/bin/agent_health_check
       - run:
           name: Create warming archive for root
           command: rosetta run warming

--- a/.github/workflows/warming.yaml
+++ b/.github/workflows/warming.yaml
@@ -9,19 +9,14 @@ on:
     # Allow this to be triggered manually via the GitHub UI Actions tab
     workflow_dispatch:
 
-# NB: Setting RUNNER_TRACKER_ID="" in the Agent health check sets prevents GitHub Actions from
-# killing the Bazel server started during health check when "Cleaning up orphan processes" in the
-# "Complete job" step. See https://github.com/actions/runner/issues/598 for more info.
-
 # TODO: migrate warming to AXL warming task once available
 jobs:
     warming-archive:
         name: Aspect Workflows Warming
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
-            - name: Workflows environment
-              run: /etc/aspect/workflows/bin/configure_workflows_env
             - uses: actions/checkout@v6
+            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
             # we still need a .aspect/workflows/config.yaml until the AXL warming task is ready
             - name: Create legacy workflows config
               run: |
@@ -30,8 +25,6 @@ jobs:
                 tasks:
                   - warming:
                 EOF
-            - name: Agent health check
-              run: RUNNER_TRACKER_ID="" && /etc/aspect/workflows/bin/agent_health_check
             - name: Create warming archive
               run: rosetta run warming
             - name: Archive warming tars

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,6 @@
+include:
+  - component: $CI_SERVER_FQDN/aspect-build/aspect-workflows-gitlab-component/setup@2026.25.5
+
 workflow:
   rules:
     # Don't create pipelines for tag pushes
@@ -13,6 +16,8 @@ test:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
+  before_script:
+    - !reference [.aspect-workflows-setup, before_script]
   script:
     - aspect test --task-key=test-gl -- //...
 
@@ -23,6 +28,8 @@ buildifier:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
+  before_script:
+    - !reference [.aspect-workflows-setup, before_script]
   script:
     - aspect buildifier --task-key=buildifier-gl
 
@@ -33,6 +40,8 @@ format:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
+  before_script:
+    - !reference [.aspect-workflows-setup, before_script]
   script:
     - aspect format --task-key=format-gl
 
@@ -43,6 +52,8 @@ gazelle:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
+  before_script:
+    - !reference [.aspect-workflows-setup, before_script]
   script:
     - aspect gazelle --task-key=gazelle-gl
 
@@ -53,6 +64,8 @@ lint:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
+  before_script:
+    - !reference [.aspect-workflows-setup, before_script]
   script:
     - aspect lint --task-key=lint-gl -- //...
 
@@ -68,6 +81,8 @@ delivery:
     - test
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
+  before_script:
+    - !reference [.aspect-workflows-setup, before_script]
   script:
     - aspect delivery --task-key=delivery-gl
 
@@ -79,20 +94,13 @@ warming:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE == "schedule"'
+  before_script:
+    - !reference [.aspect-workflows-setup, before_script]
   script:
-    - /etc/aspect/workflows/bin/gitlab_section_start "workflows_environment" "Workflows environment"
-    - /etc/aspect/workflows/bin/configure_workflows_env
-    - /etc/aspect/workflows/bin/gitlab_section_end "workflows_environment"
-    - /etc/aspect/workflows/bin/gitlab_section_start "agent_health_check" "Agent health check"
-    - /etc/aspect/workflows/bin/agent_health_check
-    - /etc/aspect/workflows/bin/gitlab_section_end "agent_health_check"
     # we still need a .aspect/workflows/config.yaml until the AXL warming task is ready
     - /etc/aspect/workflows/bin/gitlab_section_start "legacy_config" "Create legacy workflows config"
     - mkdir -p .aspect/workflows
-    - cat > .aspect/workflows/config.yaml << 'EOF'
-      tasks:
-        - warming:
-      EOF
+    - printf 'tasks:\n  - warming:\n' > .aspect/workflows/config.yaml
     - /etc/aspect/workflows/bin/gitlab_section_end "legacy_config"
     - /etc/aspect/workflows/bin/gitlab_section_start "warming" "Warming"
     - rosetta run warming

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,8 +16,7 @@ test:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
-  before_script:
-    - !reference [.aspect-workflows-setup, before_script]
+  extends: .aspect-workflows-setup
   script:
     - aspect test --task-key=test-gl -- //...
 
@@ -28,8 +27,7 @@ buildifier:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
-  before_script:
-    - !reference [.aspect-workflows-setup, before_script]
+  extends: .aspect-workflows-setup
   script:
     - aspect buildifier --task-key=buildifier-gl
 
@@ -40,8 +38,7 @@ format:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
-  before_script:
-    - !reference [.aspect-workflows-setup, before_script]
+  extends: .aspect-workflows-setup
   script:
     - aspect format --task-key=format-gl
 
@@ -52,8 +49,7 @@ gazelle:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
-  before_script:
-    - !reference [.aspect-workflows-setup, before_script]
+  extends: .aspect-workflows-setup
   script:
     - aspect gazelle --task-key=gazelle-gl
 
@@ -64,8 +60,7 @@ lint:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
-  before_script:
-    - !reference [.aspect-workflows-setup, before_script]
+  extends: .aspect-workflows-setup
   script:
     - aspect lint --task-key=lint-gl -- //...
 
@@ -81,8 +76,7 @@ delivery:
     - test
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
-  before_script:
-    - !reference [.aspect-workflows-setup, before_script]
+  extends: .aspect-workflows-setup
   script:
     - aspect delivery --task-key=delivery-gl
 
@@ -94,8 +88,7 @@ warming:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE == "schedule"'
-  before_script:
-    - !reference [.aspect-workflows-setup, before_script]
+  extends: .aspect-workflows-setup
   script:
     # we still need a .aspect/workflows/config.yaml until the AXL warming task is ready
     - /etc/aspect/workflows/bin/gitlab_section_start "legacy_config" "Create legacy workflows config"


### PR DESCRIPTION
Adopts the [Aspect Workflows GitLab CI/CD component](https://gitlab.com/aspect-build/aspect-workflows-gitlab-component) (`@2026.25.5`) on `main`, bringing GitLab to parity with CircleCI (orb) and Buildkite (plugin), which already use their integrations here.

- **`.gitlab-ci.yml`**: `include`s the component and every job (build/test/format/lint/delivery + warming) uses `extends: .aspect-workflows-setup`. The component waits for the runner's cache warming and writes `/etc/bazel.bazelrc`, so raw `bazel` calls route through the runner's remote cache, BES backend, and NVMe disk cache.
- **Warming jobs across all three providers** (GitLab, CircleCI, GitHub `warming.yaml`): drop the now-redundant `configure_workflows_env` and `agent_health_check` pre-steps — the setup integration handles environment config and waits for warming, so the explicit pre-steps are no longer needed.

The component was verified end-to-end earlier (a prior test pipeline logged the setup step: runner metadata + "Wrote Workflows-tuned bazelrc to /etc/bazel.bazelrc", with `Group queue: aspect-default` correct).

### Changes are visible to end-users: no

### Test plan

- `circleci config validate` passes; `.gitlab-ci.yml` parses; GitHub `warming.yaml` has no real actionlint errors.
- GitLab/CircleCI/GitHub CI on this PR exercise the integrations on real Aspect Workflows runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
