### PR TITLE
Add RBE showcase demo example + manual fan-out workflow

### DIFF
--- a/.github/workflows/rbe-showcase.yaml
+++ b/.github/workflows/rbe-showcase.yaml
@@ -1,0 +1,127 @@
+name: Demo - RBE Showcase
+
+# Manual demo of Remote Build Execution fan-out. Dispatch this workflow, tune
+# the matrix size and Bazel concurrency, and watch a few hundred independent
+# compile-heavy units fan out across the Aspect Workflows remote executors.
+#
+# The matrix targets live in //rbe-showcase and are tagged `manual`, so they are
+# never built by the regular CI (`//...`). This workflow names the
+# //rbe-showcase:matrix test_suite explicitly, which is the only way they run.
+#
+# See rbe-showcase/README.md for how the sizing knobs map to compile cost and
+# the (memory-constrained) sizing guidance.
+
+on:
+    workflow_dispatch:
+        inputs:
+            count:
+                description: "Independent compile + test units in the matrix (fan-out width)."
+                required: true
+                default: "200"
+            funcs:
+                description: "Template functions per unit (linear compile-cost knob)."
+                required: true
+                default: "200"
+            tmpl_depth:
+                description: "Node<> template recursion depth. SUPERLINEAR + memory-hungry: each +1 ~doubles per-unit compile cost AND RSS. Raise carefully."
+                required: true
+                default: "9"
+            test_iters:
+                description: "LCG iterations per test (~16s/test at 200000000; runtime fan-out knob)."
+                required: true
+                default: "200000000"
+            jobs:
+                description: "Bazel --jobs: how many remote actions to request concurrently (the scaling knob)."
+                required: true
+                default: "32"
+            rerun_tests:
+                description: "Force tests to re-run instead of taking cached results (shows the full test fan-out every time)."
+                type: boolean
+                default: true
+            extra_bazel_flags:
+                description: "Extra Bazel flags appended verbatim (e.g. --remote_download_outputs=minimal)."
+                required: false
+                default: ""
+
+permissions:
+    id-token: write
+
+concurrency:
+    # Serialize demo runs so two dispatches don't fight over the matrix sources.
+    group: ${{ github.workflow }}
+    cancel-in-progress: false
+
+jobs:
+    showcase:
+        runs-on: [self-hosted, aspect-workflows, aspect-default]
+        timeout-minutes: 60
+        # All dispatch inputs are exposed as env vars (never interpolated
+        # directly into run: scripts) so a crafted value cannot inject shell or
+        # sed commands. The numeric ones are additionally validated below.
+        env:
+            COUNT: ${{ inputs.count }}
+            FUNCS: ${{ inputs.funcs }}
+            TMPL_DEPTH: ${{ inputs.tmpl_depth }}
+            TEST_ITERS: ${{ inputs.test_iters }}
+            JOBS: ${{ inputs.jobs }}
+            RERUN_TESTS: ${{ inputs.rerun_tests }}
+            EXTRA: ${{ inputs.extra_bazel_flags }}
+        steps:
+            - uses: actions/checkout@v6
+            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
+              with:
+                aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
+
+            - name: Validate inputs
+              run: |
+                set -euo pipefail
+                for pair in "count:$COUNT" "funcs:$FUNCS" "tmpl_depth:$TMPL_DEPTH" "test_iters:$TEST_ITERS" "jobs:$JOBS"; do
+                  name=${pair%%:*}
+                  val=${pair#*:}
+                  if ! [[ "$val" =~ ^[0-9]+$ ]]; then
+                    echo "::error::input '$name' must be a non-negative integer, got: $val"
+                    exit 1
+                  fi
+                done
+
+            - name: Size the matrix
+              run: |
+                set -euo pipefail
+                build="rbe-showcase/BUILD.bazel"
+                # Rewrite the rbe_matrix(...) knobs in place from the (validated,
+                # integer-only) inputs. Patterns are anchored to leading
+                # indentation so only the macro-call lines are touched.
+                sed -E -i \
+                  -e "s/^( +count = )[0-9]+,/\1${COUNT},/" \
+                  -e "s/^( +funcs = )[0-9]+,/\1${FUNCS},/" \
+                  -e "s/^( +tmpl_depth = )[0-9]+,/\1${TMPL_DEPTH},/" \
+                  -e "s/^( +test_iters = )[0-9]+,/\1${TEST_ITERS},/" \
+                  "$build"
+                {
+                  echo "## RBE showcase config"
+                  echo '```python'
+                  sed -n '/^rbe_matrix(/,/^)/p' "$build"
+                  echo '```'
+                  echo "jobs=${JOBS}  rerun_tests=${RERUN_TESTS}"
+                } >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Test on RBE
+              run: |
+                set -euo pipefail
+                flags=(--config=rbe "--jobs=${JOBS}")
+                if [ "$RERUN_TESTS" = "true" ]; then
+                  flags+=(--nocache_test_results)
+                fi
+                # Word-split EXTRA into separate args. Env-var expansion performs
+                # no command substitution, so this only ever yields plain args.
+                # shellcheck disable=SC2206
+                flags+=(${EXTRA})
+
+                start=$(date +%s)
+                aspect test --task:name=rbe-showcase "${flags[@]}" -- //rbe-showcase:matrix
+                end=$(date +%s)
+
+                {
+                  echo "### Result"
+                  echo "RBE wall time: **$((end - start))s** for ${COUNT} units (--jobs=${JOBS})."
+                } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rbe-showcase.yaml
+++ b/.github/workflows/rbe-showcase.yaml
@@ -12,116 +12,116 @@ name: Demo - RBE Showcase
 # the (memory-constrained) sizing guidance.
 
 on:
-    workflow_dispatch:
-        inputs:
-            count:
-                description: "Independent compile + test units in the matrix (fan-out width)."
-                required: true
-                default: "200"
-            funcs:
-                description: "Template functions per unit (linear compile-cost knob)."
-                required: true
-                default: "200"
-            tmpl_depth:
-                description: "Node<> template recursion depth. SUPERLINEAR + memory-hungry: each +1 ~doubles per-unit compile cost AND RSS. Raise carefully."
-                required: true
-                default: "9"
-            test_iters:
-                description: "LCG iterations per test (~16s/test at 200000000; runtime fan-out knob)."
-                required: true
-                default: "200000000"
-            jobs:
-                description: "Bazel --jobs: how many remote actions to request concurrently (the scaling knob)."
-                required: true
-                default: "32"
-            rerun_tests:
-                description: "Force tests to re-run instead of taking cached results (shows the full test fan-out every time)."
-                type: boolean
-                default: true
-            extra_bazel_flags:
-                description: "Extra Bazel flags appended verbatim (e.g. --remote_download_outputs=minimal)."
-                required: false
-                default: ""
+  workflow_dispatch:
+    inputs:
+      count:
+        description: 'Independent compile + test units in the matrix (fan-out width).'
+        required: true
+        default: '200'
+      funcs:
+        description: 'Template functions per unit (linear compile-cost knob).'
+        required: true
+        default: '200'
+      tmpl_depth:
+        description: 'Node<> template recursion depth. SUPERLINEAR + memory-hungry: each +1 ~doubles per-unit compile cost AND RSS. Raise carefully.'
+        required: true
+        default: '9'
+      test_iters:
+        description: 'LCG iterations per test (~16s/test at 200000000; runtime fan-out knob).'
+        required: true
+        default: '200000000'
+      jobs:
+        description: 'Bazel --jobs: how many remote actions to request concurrently (the scaling knob).'
+        required: true
+        default: '32'
+      rerun_tests:
+        description: 'Force tests to re-run instead of taking cached results (shows the full test fan-out every time).'
+        type: boolean
+        default: true
+      extra_bazel_flags:
+        description: 'Extra Bazel flags appended verbatim (e.g. --remote_download_outputs=minimal).'
+        required: false
+        default: ''
 
 permissions:
-    id-token: write
+  id-token: write
 
 concurrency:
-    # Serialize demo runs so two dispatches don't fight over the matrix sources.
-    group: ${{ github.workflow }}
-    cancel-in-progress: false
+  # Serialize demo runs so two dispatches don't fight over the matrix sources.
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
-    showcase:
-        runs-on: [self-hosted, aspect-workflows, aspect-default]
-        timeout-minutes: 60
-        # All dispatch inputs are exposed as env vars (never interpolated
-        # directly into run: scripts) so a crafted value cannot inject shell or
-        # sed commands. The numeric ones are additionally validated below.
-        env:
-            COUNT: ${{ inputs.count }}
-            FUNCS: ${{ inputs.funcs }}
-            TMPL_DEPTH: ${{ inputs.tmpl_depth }}
-            TEST_ITERS: ${{ inputs.test_iters }}
-            JOBS: ${{ inputs.jobs }}
-            RERUN_TESTS: ${{ inputs.rerun_tests }}
-            EXTRA: ${{ inputs.extra_bazel_flags }}
-        steps:
-            - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
-              with:
-                aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
+  showcase:
+    runs-on: [self-hosted, aspect-workflows, aspect-default]
+    timeout-minutes: 60
+    # All dispatch inputs are exposed as env vars (never interpolated
+    # directly into run: scripts) so a crafted value cannot inject shell or
+    # sed commands. The numeric ones are additionally validated below.
+    env:
+      COUNT: ${{ inputs.count }}
+      FUNCS: ${{ inputs.funcs }}
+      TMPL_DEPTH: ${{ inputs.tmpl_depth }}
+      TEST_ITERS: ${{ inputs.test_iters }}
+      JOBS: ${{ inputs.jobs }}
+      RERUN_TESTS: ${{ inputs.rerun_tests }}
+      EXTRA: ${{ inputs.extra_bazel_flags }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
+        with:
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
 
-            - name: Validate inputs
-              run: |
-                set -euo pipefail
-                for pair in "count:$COUNT" "funcs:$FUNCS" "tmpl_depth:$TMPL_DEPTH" "test_iters:$TEST_ITERS" "jobs:$JOBS"; do
-                  name=${pair%%:*}
-                  val=${pair#*:}
-                  if ! [[ "$val" =~ ^[0-9]+$ ]]; then
-                    echo "::error::input '$name' must be a non-negative integer, got: $val"
-                    exit 1
-                  fi
-                done
+      - name: Validate inputs
+        run: |
+          set -euo pipefail
+          for pair in "count:$COUNT" "funcs:$FUNCS" "tmpl_depth:$TMPL_DEPTH" "test_iters:$TEST_ITERS" "jobs:$JOBS"; do
+            name=${pair%%:*}
+            val=${pair#*:}
+            if ! [[ "$val" =~ ^[0-9]+$ ]]; then
+              echo "::error::input '$name' must be a non-negative integer, got: $val"
+              exit 1
+            fi
+          done
 
-            - name: Size the matrix
-              run: |
-                set -euo pipefail
-                build="rbe-showcase/BUILD.bazel"
-                # Rewrite the rbe_matrix(...) knobs in place from the (validated,
-                # integer-only) inputs. Patterns are anchored to leading
-                # indentation so only the macro-call lines are touched.
-                sed -E -i \
-                  -e "s/^( +count = )[0-9]+,/\1${COUNT},/" \
-                  -e "s/^( +funcs = )[0-9]+,/\1${FUNCS},/" \
-                  -e "s/^( +tmpl_depth = )[0-9]+,/\1${TMPL_DEPTH},/" \
-                  -e "s/^( +test_iters = )[0-9]+,/\1${TEST_ITERS},/" \
-                  "$build"
-                {
-                  echo "## RBE showcase config"
-                  echo '```python'
-                  sed -n '/^rbe_matrix(/,/^)/p' "$build"
-                  echo '```'
-                  echo "jobs=${JOBS}  rerun_tests=${RERUN_TESTS}"
-                } >> "$GITHUB_STEP_SUMMARY"
+      - name: Size the matrix
+        run: |
+          set -euo pipefail
+          build="rbe-showcase/BUILD.bazel"
+          # Rewrite the rbe_matrix(...) knobs in place from the (validated,
+          # integer-only) inputs. Patterns are anchored to leading
+          # indentation so only the macro-call lines are touched.
+          sed -E -i \
+            -e "s/^( +count = )[0-9]+,/\1${COUNT},/" \
+            -e "s/^( +funcs = )[0-9]+,/\1${FUNCS},/" \
+            -e "s/^( +tmpl_depth = )[0-9]+,/\1${TMPL_DEPTH},/" \
+            -e "s/^( +test_iters = )[0-9]+,/\1${TEST_ITERS},/" \
+            "$build"
+          {
+            echo "## RBE showcase config"
+            echo '```python'
+            sed -n '/^rbe_matrix(/,/^)/p' "$build"
+            echo '```'
+            echo "jobs=${JOBS}  rerun_tests=${RERUN_TESTS}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-            - name: Test on RBE
-              run: |
-                set -euo pipefail
-                flags=(--config=rbe "--jobs=${JOBS}")
-                if [ "$RERUN_TESTS" = "true" ]; then
-                  flags+=(--nocache_test_results)
-                fi
-                # Word-split EXTRA into separate args. Env-var expansion performs
-                # no command substitution, so this only ever yields plain args.
-                # shellcheck disable=SC2206
-                flags+=(${EXTRA})
+      - name: Test on RBE
+        run: |
+          set -euo pipefail
+          flags=(--config=rbe "--jobs=${JOBS}")
+          if [ "$RERUN_TESTS" = "true" ]; then
+            flags+=(--nocache_test_results)
+          fi
+          # Word-split EXTRA into separate args. Env-var expansion performs
+          # no command substitution, so this only ever yields plain args.
+          # shellcheck disable=SC2206
+          flags+=(${EXTRA})
 
-                start=$(date +%s)
-                aspect test --task:name=rbe-showcase "${flags[@]}" -- //rbe-showcase:matrix
-                end=$(date +%s)
+          start=$(date +%s)
+          aspect test --task:name=rbe-showcase "${flags[@]}" -- //rbe-showcase:matrix
+          end=$(date +%s)
 
-                {
-                  echo "### Result"
-                  echo "RBE wall time: **$((end - start))s** for ${COUNT} units (--jobs=${JOBS})."
-                } >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Result"
+            echo "RBE wall time: **$((end - start))s** for ${COUNT} units (--jobs=${JOBS})."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/rbe-showcase/BUILD.bazel
+++ b/rbe-showcase/BUILD.bazel
@@ -1,0 +1,34 @@
+# gazelle:ignore
+load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//rbe-showcase:defs.bzl", "rbe_matrix")
+
+py_binary(
+    name = "codegen",
+    srcs = ["codegen.py"],
+    main = "codegen.py",
+    visibility = ["//rbe-showcase:__subpackages__"],
+)
+
+sh_test(
+    name = "codegen_determinism_test",
+    srcs = ["codegen_determinism_test.sh"],
+    data = [":codegen"],
+)
+
+# Sizing is MEMORY-CONSTRAINED, not just CPU: clang RSS scales with template
+# instantiations (~0.8 GB/unit at these knobs). Peak local build memory is
+# roughly RSS-per-unit x --jobs. Do NOT raise tmpl_depth without re-measuring a
+# single unit with `/usr/bin/time -l` first — it grows ~2x per depth step. See
+# README.md.
+#
+# Every target this macro generates is tagged `manual`, so `bazel test //...`
+# (and the repo's CI) skip the matrix. Run it explicitly for a demo:
+#   bazel test --config=rbe //rbe-showcase:matrix
+rbe_matrix(
+    name = "matrix",
+    count = 200,
+    funcs = 200,
+    test_iters = 200000000,
+    tmpl_depth = 9,
+)

--- a/rbe-showcase/README.md
+++ b/rbe-showcase/README.md
@@ -1,0 +1,99 @@
+# RBE showcase
+
+A wide, shallow matrix of independent, compile-heavy C++ build + test units,
+designed to make the difference between local execution and
+[Remote Build Execution (RBE)](https://aspect.build/docs/cli/remote-execution)
+obvious in a single command.
+
+Every unit is independent, so RBE fans the whole matrix out across remote
+workers in parallel while a single laptop has to grind through it serially. The
+work is real compiler work — not a `sleep` — so the timings reflect what RBE
+does for a genuinely expensive build.
+
+## How it works
+
+`codegen.py` emits a tiny (tens of KB) C++ translation unit whose compile cost
+is dominated by template metaprogramming: each generated function instantiates a
+binary-branching recursive class template `Node<Tag, N>`. Every level forks into
+two children with distinct, prime-perturbed tags, so the compiler cannot memoize
+subtrees — it must materialize ~2^`tmpl_depth` distinct specializations per
+function. The result is a `constexpr` fold, so the cost lands entirely on the
+compiler; the runtime sees a folded constant.
+
+This makes compile cost **superlinear** in the knobs — roughly linear in `funcs`
+and exponential in `tmpl_depth` — while keeping each source file small. Test
+runtime is a separate, CPU-bound LCG loop driven by `test_iters`, independent of
+compile cost, so the two costs can be tuned separately.
+
+`rbe_matrix` (see [`defs.bzl`](./defs.bzl)) stamps out `count` copies of this
+unit as independent `cc_library` + `cc_test` pairs.
+
+## Running it
+
+The matrix targets are all tagged `manual`, so they are **excluded from
+`//...`** — neither the repo's CI nor a casual `bazel test //...` will pull them
+in (compiling hundreds of these at once is memory-hungry; see below). Run the
+demo by naming the `matrix` test_suite explicitly.
+
+Locally (serial — slow, the "before"):
+
+```sh
+bazel test //rbe-showcase:matrix
+```
+
+On RBE (fanned out — fast, the "after"):
+
+```sh
+bazel test --config=rbe //rbe-showcase:matrix
+```
+
+The codegen itself has a fast, CI-safe determinism check (generated sources must
+be byte-identical across runs for the matrix to be cache-friendly):
+
+```sh
+bazel test //rbe-showcase:codegen_determinism_test
+```
+
+## Knobs
+
+Set in [`BUILD.bazel`](./BUILD.bazel) via the `rbe_matrix(...)` call:
+
+| knob         | default   | meaning |
+|--------------|-----------|---------|
+| `count`      | 200       | independent compile + test units in the matrix |
+| `funcs`      | 200       | template functions per unit (linear compile cost **and** RSS) |
+| `tmpl_depth` | 9         | `Node<>` recursion depth (each +1 ≈ doubles compile cost **and** RSS) |
+| `test_iters` | 200000000 | LCG iterations per test (~16 s/test; runtime knob, memory-trivial) |
+
+`tmpl_depth` stays well under the default `-ftemplate-depth` / `-fconstexpr-depth`
+limits, so no compiler flags are required — plain, portable C++17.
+
+## ⚠️ Sizing is memory-constrained, not just CPU
+
+Compile cost is capped by compiler **memory**, not CPU. The compiler retains the
+AST for every template specialization for the whole translation unit, so RSS
+scales with instantiation count the same way CPU does — roughly **~2 s CPU per
+~1 GB peak RSS** near these defaults, and it grows ~2× for every `+1` of
+`tmpl_depth`. Bazel then multiplies per-unit RSS by `--jobs` (defaults to your
+core count), so peak local build memory is approximately
+`RSS-per-unit × jobs`.
+
+At the defaults above (`tmpl_depth = 9`, ≈0.8 GB/unit) an 18-core machine peaks
+around 14 GB during the build phase — fine. **Do not raise `tmpl_depth` or
+`funcs` without first measuring a single unit** (e.g. with `/usr/bin/time -l`)
+and multiplying peak RSS by your core count: a couple of depth steps higher is
+enough to exhaust a laptop's RAM. If you're demoing with a browser or video call
+open, throttle the build with `--jobs=8`.
+
+## Approximate timings
+
+Illustrative, at the defaults (`count = 200`, `funcs = 200`, `tmpl_depth = 9`):
+
+| environment                  | wall time (cold) |
+|------------------------------|------------------|
+| 18-core workstation, local   | ~3–4 min         |
+| typical 4-core laptop, local | ~15 min          |
+| RBE, warm cache              | < 1 min          |
+
+The RBE win comes from fan-out: the whole matrix executes across many remote
+workers concurrently, while a single machine is bounded by its core count.

--- a/rbe-showcase/codegen.py
+++ b/rbe-showcase/codegen.py
@@ -1,0 +1,118 @@
+"""Emit a compile-heavy C++ translation unit and its test.
+
+Compile cost comes from template metaprogramming: each generated function
+instantiates a binary-branching recursive class template `Node<Tag, N>`. Every
+level splits into two children with distinct, prime-perturbed tags, so the
+compiler cannot memoize the subtrees away — it must materialize ~2^depth
+distinct specializations per function, each with a progressively longer mangled
+name. The result (`Node<...>::value`) is a constexpr fold, so it costs the
+compiler dearly but the runtime sees only a folded constant.
+
+This makes compile cost SUPERLINEAR in the chosen knobs: roughly linear in
+`funcs` and exponential in `tmpl_depth` (each +1 depth ~doubles the work),
+while keeping the source file tiny (tens of KB). That is the property the RBE
+demo needs — a few hundred KB of source that takes the better part of a minute
+of CPU to compile, so a laptop grinds for ~10 min on the whole matrix while RBE
+fans the units out in parallel.
+
+Runtime test cost is kept independent of compile cost: `_work` runs a real LCG
+loop for `test_iters` iterations, seeded by the (folded) function constants.
+So `test_iters` remains the run-cost knob and `funcs`/`tmpl_depth` the
+compile-cost knobs. Output is deterministic in (unit, funcs, tmpl_depth).
+"""
+
+import argparse
+
+
+# Recursive, binary-branching class template. Each node at level N expands into
+# two children with distinct tags (different prime multipliers), so the two
+# subtrees never collapse to the same specialization. `value` is a constexpr
+# fold of both children. Specialization at N==0 terminates the recursion.
+#
+# Portable C++17: no compiler flags, no macOS/clang-only constructs. The
+# default -ftemplate-depth (1024) and -fconstexpr-depth (512) comfortably
+# accommodate the depths we use (<= ~18), so no flag tuning is required.
+_TEMPLATE = """\
+template <unsigned long Tag, int N> struct Node {
+  static constexpr unsigned long L =
+      Node<Tag * 6364136223846793005UL + 1UL, N - 1>::value;
+  static constexpr unsigned long R =
+      Node<Tag * 2862933555777941757UL + 3UL, N - 1>::value;
+  static constexpr unsigned long value = (L ^ (R * 2654435761UL)) + (Tag >> 7);
+};
+template <unsigned long Tag> struct Node<Tag, 0> {
+  static constexpr unsigned long value = Tag | 1UL;
+};"""
+
+
+def emit_lib(unit: str, funcs: int, tmpl_depth: int) -> str:
+    parts = [
+        "#include <cstdint>",
+        f"// generated: unit={unit} funcs={funcs} tmpl_depth={tmpl_depth}",
+        _TEMPLATE,
+    ]
+    for i in range(funcs):
+        # Distinct per-function root tag keeps each function's template tree
+        # independent (no cross-function memoization), so compile cost scales
+        # linearly with `funcs`.
+        tag = (i * 2654435761 + 12345) % (1 << 31)
+        parts.append(
+            f"long {unit}_f{i}(long x) {{\n"
+            f"  constexpr unsigned long c = Node<{tag}UL, {tmpl_depth}>::value;\n"
+            f"  return (long)c ^ x;\n"
+            "}"
+        )
+    # Runtime work loop: a real LCG mix, seeded by the folded constant of _f0.
+    # This is the run-cost path and is INDEPENDENT of the compile-cost template
+    # (the template result is a compile-time constant). `test_iters` drives it.
+    # Each iteration does several rounds of LCG so per-iteration cost stays
+    # substantial even at -O0 (bazel fastbuild), keeping `test_iters` calibrated
+    # to ~15s at 200M iters — i.e. the same run-cost meaning as before.
+    parts.append(f"long {unit}_work(long iters) {{")
+    parts.append(f"  long acc = {unit}_f0(1);")
+    parts.append("  for (long i = 0; i < iters; ++i) {")
+    parts.append("    for (int j = 0; j < 64; ++j) {")
+    parts.append("      acc = (acc * 6364136223846793005L + 1442695040888963407L) ^ (acc >> 31);")
+    parts.append("    }")
+    parts.append("  }")
+    parts.append("  return acc | 1L;")
+    parts.append("}")
+    return "\n".join(parts) + "\n"
+
+
+def emit_test(unit: str, iters: int) -> str:
+    return (
+        "#include <cstdio>\n"
+        f"extern long {unit}_work(long iters);\n"
+        "int main() {\n"
+        f"  long acc = {unit}_work({iters}L);\n"
+        '  if (acc == 0) { printf("unexpected zero\\n"); return 1; }\n'
+        f'  printf("{unit}: ok (%ld)\\n", acc);\n'
+        "  return 0;\n"
+        "}\n"
+    )
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--unit", required=True)
+    p.add_argument("--funcs", type=int, default=400)
+    p.add_argument(
+        "--tmpl-depth",
+        type=int,
+        default=14,
+        help="recursion depth of the Node<> template (compile-cost knob; "
+        "each +1 roughly doubles per-function compile cost)",
+    )
+    p.add_argument("--test-iters", type=int, default=200_000_000)
+    p.add_argument("--lib-out", required=True)
+    p.add_argument("--test-out", required=True)
+    args = p.parse_args()
+    with open(args.lib_out, "w") as f:
+        f.write(emit_lib(args.unit, args.funcs, args.tmpl_depth))
+    with open(args.test_out, "w") as f:
+        f.write(emit_test(args.unit, args.test_iters))
+
+
+if __name__ == "__main__":
+    main()

--- a/rbe-showcase/codegen.py
+++ b/rbe-showcase/codegen.py
@@ -72,7 +72,9 @@ def emit_lib(unit: str, funcs: int, tmpl_depth: int) -> str:
     parts.append(f"  long acc = {unit}_f0(1);")
     parts.append("  for (long i = 0; i < iters; ++i) {")
     parts.append("    for (int j = 0; j < 64; ++j) {")
-    parts.append("      acc = (acc * 6364136223846793005L + 1442695040888963407L) ^ (acc >> 31);")
+    parts.append(
+        "      acc = (acc * 6364136223846793005L + 1442695040888963407L) ^ (acc >> 31);"
+    )
     parts.append("    }")
     parts.append("  }")
     parts.append("  return acc | 1L;")

--- a/rbe-showcase/codegen_determinism_test.sh
+++ b/rbe-showcase/codegen_determinism_test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Generated sources must be byte-identical across runs — cache-friendliness
+# of the whole matrix depends on it.
+set -euo pipefail
+CODEGEN="rbe-showcase/codegen"
+"$CODEGEN" --unit det --funcs 5 --test-iters 100 --lib-out a.cc --test-out a_test.cc
+"$CODEGEN" --unit det --funcs 5 --test-iters 100 --lib-out b.cc --test-out b_test.cc
+diff a.cc b.cc
+diff a_test.cc b_test.cc
+echo "deterministic: ok"

--- a/rbe-showcase/defs.bzl
+++ b/rbe-showcase/defs.bzl
@@ -1,0 +1,87 @@
+"""rbe_matrix: a wide, shallow matrix of compile-heavy compile + test targets.
+
+Demonstrates RBE fan-out: every unit is independent, so remote execution
+parallelizes the whole matrix while a laptop grinds through it serially.
+Sizing knobs:
+  count        number of independent units
+  funcs        functions per unit (linear compile-cost knob)
+  tmpl_depth   Node<> template recursion depth (superlinear compile-cost knob;
+               each +1 roughly doubles per-function compile cost)
+  test_iters   LCG iterations per test (runtime cost/test knob)
+See README.md for sizing guidance and target timings.
+
+Every generated target is tagged `manual` so the matrix is excluded from
+wildcard patterns (`//...`). That keeps it out of the repo's CI test run and
+out of a casual local `bazel test //...` (compiling hundreds of these units at
+once is memory-hungry — see README.md). Run the demo explicitly via the
+generated `<name>` test_suite, e.g.:
+
+    bazel test --config=rbe //rbe-showcase:matrix
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+# Tag applied to every generated target so it is skipped by wildcard target
+# patterns (`//...`, `//rbe-showcase/...`). Demo runs name the test_suite
+# explicitly, which bypasses the wildcard exclusion.
+_MANUAL = ["manual"]
+
+def rbe_matrix(name, count = 150, funcs = 400, tmpl_depth = 14, test_iters = 200000000):
+    """Stamp out `count` independent compile-heavy cc_library + cc_test units.
+
+    All generated targets are tagged `manual`; run the demo via the generated
+    `name` test_suite (see the module docstring).
+
+    Args:
+      name: base name; also the name of the generated test_suite.
+      count: number of independent compile + test units.
+      funcs: template functions per unit (linear compile-cost knob).
+      tmpl_depth: Node<> recursion depth (superlinear compile-cost knob; each
+        +1 roughly doubles per-function compile cost and peak RSS).
+      test_iters: LCG iterations per test (runtime cost-per-test knob).
+    """
+    units = []
+    tests = []
+    for i in range(count):
+        # Starlark doesn't support zero-padding via %03d; format manually.
+        suffix = str(i)
+        if i < 10:
+            suffix = "00" + suffix
+        elif i < 100:
+            suffix = "0" + suffix
+        unit = "%s_u%s" % (name, suffix)
+        native.genrule(
+            name = unit + "_srcs",
+            outs = [unit + ".cc", unit + "_test.cc"],
+            cmd = "$(location //rbe-showcase:codegen) --unit {unit} --funcs {funcs} --tmpl-depth {depth} --test-iters {iters} --lib-out $(location {unit}.cc) --test-out $(location {unit}_test.cc)".format(
+                unit = unit,
+                funcs = funcs,
+                depth = tmpl_depth,
+                iters = test_iters,
+            ),
+            tools = ["//rbe-showcase:codegen"],
+            tags = _MANUAL,
+        )
+        cc_library(
+            name = unit,
+            srcs = [unit + ".cc"],
+            tags = _MANUAL,
+        )
+        cc_test(
+            name = unit + "_test",
+            size = "medium",
+            srcs = [unit + "_test.cc"],
+            deps = [":" + unit],
+            tags = _MANUAL,
+        )
+        units.append(unit)
+        tests.append(":" + unit + "_test")
+
+    # Explicit demo entry point. Tagged `manual` so `//...` skips it; naming it
+    # directly (`bazel test //rbe-showcase:<name>`) runs every unit test in the
+    # matrix because the `tests` attribute references them explicitly.
+    native.test_suite(
+        name = name,
+        tests = tests,
+        tags = _MANUAL,
+    )


### PR DESCRIPTION
## What

Brings the RBE showcase from `se-demo-examples` into this repo as `//rbe-showcase`, plus a manual GitHub Actions workflow to run it on the Aspect Workflows RBE runners for customer demos.

`codegen.py` emits compile-heavy C++ translation units (binary-branching recursive template metaprogramming) whose compile cost is superlinear in the sizing knobs while the source stays tiny. `rbe_matrix` (`defs.bzl`) stamps out `count` independent `cc_library` + `cc_test` units — the fan-out RBE parallelizes and a laptop grinds through serially.

## Excluded from `//...`

Every generated target is tagged `manual`, so the heavy matrix is **never** pulled into the repo's CI (`aspect test -- //...`) or a casual local `bazel test //...` (compiling hundreds of these at once is memory-hungry). The macro emits a `//rbe-showcase:matrix` test_suite as the explicit demo entry point:

```sh
bazel test //rbe-showcase:matrix              # local — slow ("before")
bazel test --config=rbe //rbe-showcase:matrix # RBE fan-out — fast ("after")
```

The fast `codegen_determinism_test` stays **non-manual**, so the codegen keeps getting exercised in normal CI.

## Manual demo workflow

`.github/workflows/rbe-showcase.yaml` — `workflow_dispatch` with tunable `count` / `funcs` / `tmpl_depth` / `test_iters` / `jobs` (+ `rerun_tests`, `extra_bazel_flags`) to demo fan-out and scaling. It rewrites the `rbe_matrix(...)` knobs from the dispatch inputs, runs `aspect test --config=rbe //rbe-showcase:matrix`, and writes the config + wall time to the run summary. Numeric inputs are integer-validated and all inputs flow through `env:` (no direct `${{ inputs }}` in `run:`) to prevent shell/sed injection.

## CALIBRATION.md → README.md

The internal `CALIBRATION.md` was **not** ported verbatim (this repo is public). Its useful sizing/knob guidance and the memory-constraint warning are folded into a customer-facing `README.md`; the internal incident narrative and demo-deployment names were dropped.

## Verification

Run locally with vanilla `bazel` (`--config=rbe` is only reachable on the demo deployment):

- `bazel test //rbe-showcase/...` → only the non-manual determinism test matches (matrix correctly excluded)
- `//rbe-showcase:matrix` expands to all 200 unit tests
- `codegen_determinism_test` → PASSED
- one unit end-to-end (`matrix_u000_test`) → PASSED in 14.4s
- buildifier (format + lint), shellcheck, ruff → clean
- workflow YAML parses; the `sed` knob-rewrite produces a buildifier-clean BUILD.bazel

> Not verifiable locally: an actual `--config=rbe` run (needs the RBE backend) and a live `workflow_dispatch`. Worth a smoke dispatch once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)