### PR TITLE
Fix rbe-showcase demo: pass bazel flags via user.bazelrc

### DIFF
--- a/.github/workflows/rbe-showcase.yaml
+++ b/.github/workflows/rbe-showcase.yaml
@@ -108,17 +108,20 @@ jobs:
       - name: Test on RBE
         run: |
           set -euo pipefail
-          flags=(--config=rbe "--jobs=${JOBS}")
-          if [ "$RERUN_TESTS" = "true" ]; then
-            flags+=(--nocache_test_results)
-          fi
-          # Word-split EXTRA into separate args. Env-var expansion performs
-          # no command substitution, so this only ever yields plain args.
-          # shellcheck disable=SC2206
-          flags+=(${EXTRA})
+          # Pass per-dispatch bazel flags via user.bazelrc instead of the aspect
+          # CLI: aspect reserves --config (so it can't sit before `--`), and
+          # anything after `--` is parsed by bazel as a target, not a flag.
+          # .bazelrc ends with `try-import %workspace%/user.bazelrc`, so flags
+          # written here are read and forwarded by aspect. --config=rbe is
+          # already injected on Workflows runners, so we don't repeat it.
+          {
+            echo "test --jobs=${JOBS}"
+            if [ "$RERUN_TESTS" = "true" ]; then echo "test --nocache_test_results"; fi
+            if [ -n "${EXTRA}" ]; then echo "test ${EXTRA}"; fi
+          } > user.bazelrc
 
           start=$(date +%s)
-          aspect test --task:name=rbe-showcase "${flags[@]}" -- //rbe-showcase:matrix
+          aspect test --task:name=rbe-showcase -- //rbe-showcase:matrix
           end=$(date +%s)
 
           {


### PR DESCRIPTION
## Problem

The `Demo - RBE Showcase` workflow added in #586 fails when it runs `aspect test`:

```
error: unexpected argument '--config' found
...
ERROR: Skipping '-nocache_test_results': no such target '//:-nocache_test_results'
```

Two flag-passing dead-ends with the aspect CLI:
- **Before `--`**: `--config` collides with an aspect-reserved flag → "unexpected argument".
- **After `--`**: Bazel parses everything after `--` as *targets*, so `--jobs` / `--nocache_test_results` became bogus target labels.

## Fix

Write the per-dispatch bazel flags to `user.bazelrc`. `.bazelrc` already ends with `try-import %workspace%/user.bazelrc`, and aspect reads + forwards rc content — so the flags land without going through aspect's CLI parser. `--config=rbe` is dropped: it's auto-injected on Workflows runners (same as every other CI job in this repo).

```sh
{
  echo "test --jobs=${JOBS}"
  if [ "$RERUN_TESTS" = "true" ]; then echo "test --nocache_test_results"; fi
  if [ -n "${EXTRA}" ]; then echo "test ${EXTRA}"; fi
} > user.bazelrc
aspect test --task:name=rbe-showcase -- //rbe-showcase:matrix
```

## Verification

Dispatched on this branch (count=4, funcs=20, tmpl_depth=6, test_iters=1000, jobs=8, rerun_tests=true):

```
Executed 4 out of 4 tests: 4 tests pass.
→ ✅ Passed `test` task · Tests passed
```

All steps green; matrix ran on RBE. YAML parses; prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)