### PR TITLE
ci: update all 4 integrations to the released setup-aspect plugins

### DIFF
--- a/.buildkite/buildkite.yaml
+++ b/.buildkite/buildkite.yaml
@@ -4,7 +4,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/aspect-workflows#61d7547edd007a6d6a5d1e4972bf2b84b4f08faf: ~ # v2026.25.1
+    - aspect-build/setup-aspect#5a3d818431198044cf6cbd6dbff439510db9b44c: ~ # v2026.26.0
   retry:
     manual:
       allowed: true
@@ -23,7 +23,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/aspect-workflows#61d7547edd007a6d6a5d1e4972bf2b84b4f08faf: ~ # v2026.25.1
+    - aspect-build/setup-aspect#5a3d818431198044cf6cbd6dbff439510db9b44c: ~ # v2026.26.0
   retry:
     manual:
       allowed: true
@@ -42,7 +42,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/aspect-workflows#61d7547edd007a6d6a5d1e4972bf2b84b4f08faf: ~ # v2026.25.1
+    - aspect-build/setup-aspect#5a3d818431198044cf6cbd6dbff439510db9b44c: ~ # v2026.26.0
   retry:
     manual:
       allowed: true
@@ -61,7 +61,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/aspect-workflows#61d7547edd007a6d6a5d1e4972bf2b84b4f08faf: ~ # v2026.25.1
+    - aspect-build/setup-aspect#5a3d818431198044cf6cbd6dbff439510db9b44c: ~ # v2026.26.0
   retry:
     manual:
       allowed: true
@@ -80,7 +80,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/aspect-workflows#61d7547edd007a6d6a5d1e4972bf2b84b4f08faf: ~ # v2026.25.1
+    - aspect-build/setup-aspect#5a3d818431198044cf6cbd6dbff439510db9b44c: ~ # v2026.26.0
   retry:
     manual:
       allowed: true
@@ -99,7 +99,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/aspect-workflows#61d7547edd007a6d6a5d1e4972bf2b84b4f08faf: ~ # v2026.25.1
+    - aspect-build/setup-aspect#5a3d818431198044cf6cbd6dbff439510db9b44c: ~ # v2026.26.0
   retry:
     manual:
       allowed: true

--- a/.buildkite/buildkite.yaml
+++ b/.buildkite/buildkite.yaml
@@ -4,7 +4,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#5a3d818431198044cf6cbd6dbff439510db9b44c: ~ # v2026.26.0
+    - aspect-build/setup-aspect#c1ea411229b71a90b553ea60a208d4e32ccb06c9: ~ # v2026.26.1
   retry:
     manual:
       allowed: true
@@ -23,7 +23,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#5a3d818431198044cf6cbd6dbff439510db9b44c: ~ # v2026.26.0
+    - aspect-build/setup-aspect#c1ea411229b71a90b553ea60a208d4e32ccb06c9: ~ # v2026.26.1
   retry:
     manual:
       allowed: true
@@ -42,7 +42,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#5a3d818431198044cf6cbd6dbff439510db9b44c: ~ # v2026.26.0
+    - aspect-build/setup-aspect#c1ea411229b71a90b553ea60a208d4e32ccb06c9: ~ # v2026.26.1
   retry:
     manual:
       allowed: true
@@ -61,7 +61,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#5a3d818431198044cf6cbd6dbff439510db9b44c: ~ # v2026.26.0
+    - aspect-build/setup-aspect#c1ea411229b71a90b553ea60a208d4e32ccb06c9: ~ # v2026.26.1
   retry:
     manual:
       allowed: true
@@ -80,7 +80,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#5a3d818431198044cf6cbd6dbff439510db9b44c: ~ # v2026.26.0
+    - aspect-build/setup-aspect#c1ea411229b71a90b553ea60a208d4e32ccb06c9: ~ # v2026.26.1
   retry:
     manual:
       allowed: true
@@ -99,7 +99,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#5a3d818431198044cf6cbd6dbff439510db9b44c: ~ # v2026.26.0
+    - aspect-build/setup-aspect#c1ea411229b71a90b553ea60a208d4e32ccb06c9: ~ # v2026.26.1
   retry:
     manual:
       allowed: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aspect-workflows: aspect-build/aspect-workflows@2026.25.3
+  setup-aspect: aspect-build/setup-aspect@2026.26.2
 
 workflows:
   aspect-workflows:
@@ -38,7 +38,7 @@ jobs:
     working_directory: /mnt/ephemeral/workdir
     steps:
       - checkout
-      - aspect-workflows/setup
+      - setup-aspect/setup
       - run:
           name: Test
           command: aspect test --task:name=test-cci -- //...
@@ -49,7 +49,7 @@ jobs:
     working_directory: /mnt/ephemeral/workdir
     steps:
       - checkout
-      - aspect-workflows/setup
+      - setup-aspect/setup
       - run:
           name: Buildifier
           command: aspect buildifier --task:name=buildifier-cci
@@ -60,7 +60,7 @@ jobs:
     working_directory: /mnt/ephemeral/workdir
     steps:
       - checkout
-      - aspect-workflows/setup
+      - setup-aspect/setup
       - run:
           name: Format
           command: aspect format --task:name=format-cci
@@ -71,7 +71,7 @@ jobs:
     working_directory: /mnt/ephemeral/workdir
     steps:
       - checkout
-      - aspect-workflows/setup
+      - setup-aspect/setup
       - run:
           name: Gazelle
           command: aspect gazelle --task:name=gazelle-cci
@@ -82,7 +82,7 @@ jobs:
     working_directory: /mnt/ephemeral/workdir
     steps:
       - checkout
-      - aspect-workflows/setup
+      - setup-aspect/setup
       - run:
           name: Lint
           command: aspect lint  --task:name=lint-cci -- //...
@@ -93,7 +93,7 @@ jobs:
     working_directory: /mnt/ephemeral/workdir
     steps:
       - checkout
-      - aspect-workflows/setup
+      - setup-aspect/setup
       - run:
           name: Delivery
           command: aspect delivery --task:name=delivery-cci
@@ -110,7 +110,7 @@ jobs:
     working_directory: /mnt/ephemeral/workdir
     steps:
       - checkout
-      - aspect-workflows/setup
+      - setup-aspect/setup
       # we still need a .aspect/workflows/config.yaml until the AXL warming task is ready
       - run:
           name: Create legacy workflows config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  setup-aspect: aspect-build/setup-aspect@2026.26.2
+  setup-aspect: aspect-build/setup-aspect@2026.26.3
 
 workflows:
   aspect-workflows:

--- a/.github/workflows/ci-github-runners.yaml
+++ b/.github/workflows/ci-github-runners.yaml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
+            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
@@ -36,7 +36,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
+            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Gazelle
@@ -46,7 +46,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
+            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Format
@@ -56,7 +56,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
+            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Buildifier
@@ -66,7 +66,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
+            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Lint
@@ -80,7 +80,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
+            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Delivery

--- a/.github/workflows/ci-github-runners.yaml
+++ b/.github/workflows/ci-github-runners.yaml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
+            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
@@ -36,7 +36,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
+            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Gazelle
@@ -46,7 +46,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
+            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Format
@@ -56,7 +56,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
+            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Buildifier
@@ -66,7 +66,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
+            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Lint
@@ -80,7 +80,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
+            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Delivery

--- a/.github/workflows/ci-workflows-runners.yaml
+++ b/.github/workflows/ci-workflows-runners.yaml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
+            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
@@ -36,7 +36,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
+            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Gazelle
@@ -46,7 +46,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
+            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Format
@@ -56,7 +56,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
+            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Buildifier
@@ -66,7 +66,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
+            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Lint
@@ -80,7 +80,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
+            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Delivery

--- a/.github/workflows/ci-workflows-runners.yaml
+++ b/.github/workflows/ci-workflows-runners.yaml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
+            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
@@ -36,7 +36,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
+            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Gazelle
@@ -46,7 +46,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
+            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Format
@@ -56,7 +56,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
+            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Buildifier
@@ -66,7 +66,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
+            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Lint
@@ -80,7 +80,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
+            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Delivery

--- a/.github/workflows/rbe-showcase.yaml
+++ b/.github/workflows/rbe-showcase.yaml
@@ -68,7 +68,7 @@ jobs:
       EXTRA: ${{ inputs.extra_bazel_flags }}
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
+      - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
 

--- a/.github/workflows/rbe-showcase.yaml
+++ b/.github/workflows/rbe-showcase.yaml
@@ -68,7 +68,7 @@ jobs:
       EXTRA: ${{ inputs.extra_bazel_flags }}
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
+      - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
 

--- a/.github/workflows/warming.yaml
+++ b/.github/workflows/warming.yaml
@@ -16,7 +16,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
+            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
             # we still need a .aspect/workflows/config.yaml until the AXL warming task is ready
             - name: Create legacy workflows config
               run: |

--- a/.github/workflows/warming.yaml
+++ b/.github/workflows/warming.yaml
@@ -16,7 +16,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b1e9d142e86f63c10d603304daa22bf80492e24c # v2026.25.1
+            - uses: aspect-build/setup-aspect@b554bf554946cf5ea6fb18252b8027bf2c9b9b0b # v2026.26.1
             # we still need a .aspect/workflows/config.yaml until the AXL warming task is ready
             - name: Create legacy workflows config
               run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 include:
-  - component: $CI_SERVER_FQDN/aspect-build/setup-aspect-gitlab-component/setup@2026.26.0
+  - component: $CI_SERVER_FQDN/aspect-build/setup-aspect-gitlab-component/setup@2026.26.1
 
 workflow:
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 include:
-  - component: $CI_SERVER_FQDN/aspect-build/aspect-workflows-gitlab-component/setup@2026.25.5
+  - component: $CI_SERVER_FQDN/aspect-build/setup-aspect-gitlab-component/setup@2026.26.0
 
 workflow:
   rules:
@@ -16,7 +16,7 @@ test:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
-  extends: .aspect-workflows-setup
+  extends: .setup-aspect
   script:
     - aspect test --task:name=test-gl -- //...
 
@@ -27,7 +27,7 @@ buildifier:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
-  extends: .aspect-workflows-setup
+  extends: .setup-aspect
   script:
     - aspect buildifier --task:name=buildifier-gl
 
@@ -38,7 +38,7 @@ format:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
-  extends: .aspect-workflows-setup
+  extends: .setup-aspect
   script:
     - aspect format --task:name=format-gl
 
@@ -49,7 +49,7 @@ gazelle:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
-  extends: .aspect-workflows-setup
+  extends: .setup-aspect
   script:
     - aspect gazelle --task:name=gazelle-gl
 
@@ -60,7 +60,7 @@ lint:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
-  extends: .aspect-workflows-setup
+  extends: .setup-aspect
   script:
     - aspect lint --task:name=lint-gl -- //...
 
@@ -76,7 +76,7 @@ delivery:
     - test
   rules:
       - if: '$CI_PIPELINE_SOURCE != "schedule"'
-  extends: .aspect-workflows-setup
+  extends: .setup-aspect
   script:
     - aspect delivery --task:name=delivery-gl
 
@@ -88,7 +88,7 @@ warming:
   stage: Aspect Workflows
   rules:
       - if: '$CI_PIPELINE_SOURCE == "schedule"'
-  extends: .aspect-workflows-setup
+  extends: .setup-aspect
   script:
     # we still need a .aspect/workflows/config.yaml until the AXL warming task is ready
     - /etc/aspect/workflows/bin/gitlab_section_start "legacy_config" "Create legacy workflows config"


### PR DESCRIPTION
Points every CI provider at the renamed/released Aspect Workflows `setup-aspect` integrations.

| Provider | Old → New |
|---|---|
| GitHub Actions | `aspect-build/setup-aspect` v2026.25.1 → v2026.26.1 |
| Buildkite | `aspect-build/aspect-workflows#…` → `aspect-build/setup-aspect#…` v2026.26.0 (plugin id is the repo slug with `-buildkite-plugin` stripped) |
| CircleCI | orb `aspect-build/aspect-workflows@2026.25.3` → `aspect-build/setup-aspect@2026.26.2` (alias + `setup` command renamed to match) |
| GitLab | component `aspect-workflows-gitlab-component/setup@2026.25.5` → `setup-aspect-gitlab-component/setup@2026.26.0`, and the job-template anchor `extends: .aspect-workflows-setup` → `.setup-aspect` |

Runner queue tags/labels (`aspect-workflows`, `aspect-default`), CircleCI workflow names, and `.aspect/workflows/` config paths are unchanged — those aren't the plugin names.

### Notes for review

- The plugins now *prefer* `aspect ci bazelrc`, which is still in flight in aspect-build/aspect-cli#1295. Until that CLI ships on the runner image, the plugins fall back to `rosetta bazelrc` (the designed graceful fallback), so CI should still pass.
- The warming jobs still use `rosetta run warming` (the `aspect ci warming` AXL task isn't released yet — TODO comments retained in each config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
