### PR TITLE
ci: bump setup-aspect plugins to latest releases

### DIFF
--- a/.buildkite/buildkite.yaml
+++ b/.buildkite/buildkite.yaml
@@ -4,7 +4,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#c1ea411229b71a90b553ea60a208d4e32ccb06c9: ~ # v2026.26.1
+    - aspect-build/setup-aspect#34570cb8821b4d8d3549752b0bae70027cfc882b: ~ # v2026.26.4
   retry:
     manual:
       allowed: true
@@ -23,7 +23,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#c1ea411229b71a90b553ea60a208d4e32ccb06c9: ~ # v2026.26.1
+    - aspect-build/setup-aspect#34570cb8821b4d8d3549752b0bae70027cfc882b: ~ # v2026.26.4
   retry:
     manual:
       allowed: true
@@ -42,7 +42,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#c1ea411229b71a90b553ea60a208d4e32ccb06c9: ~ # v2026.26.1
+    - aspect-build/setup-aspect#34570cb8821b4d8d3549752b0bae70027cfc882b: ~ # v2026.26.4
   retry:
     manual:
       allowed: true
@@ -61,7 +61,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#c1ea411229b71a90b553ea60a208d4e32ccb06c9: ~ # v2026.26.1
+    - aspect-build/setup-aspect#34570cb8821b4d8d3549752b0bae70027cfc882b: ~ # v2026.26.4
   retry:
     manual:
       allowed: true
@@ -80,7 +80,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#c1ea411229b71a90b553ea60a208d4e32ccb06c9: ~ # v2026.26.1
+    - aspect-build/setup-aspect#34570cb8821b4d8d3549752b0bae70027cfc882b: ~ # v2026.26.4
   retry:
     manual:
       allowed: true
@@ -99,7 +99,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#c1ea411229b71a90b553ea60a208d4e32ccb06c9: ~ # v2026.26.1
+    - aspect-build/setup-aspect#34570cb8821b4d8d3549752b0bae70027cfc882b: ~ # v2026.26.4
   retry:
     manual:
       allowed: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  setup-aspect: aspect-build/setup-aspect@2026.26.3
+  setup-aspect: aspect-build/setup-aspect@2026.26.6
 
 workflows:
   aspect-workflows:

--- a/.github/workflows/ci-github-runners.yaml
+++ b/.github/workflows/ci-github-runners.yaml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
+            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
@@ -36,7 +36,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
+            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Gazelle
@@ -46,7 +46,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
+            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Format
@@ -56,7 +56,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
+            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Buildifier
@@ -66,7 +66,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
+            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Lint
@@ -80,7 +80,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
+            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Delivery

--- a/.github/workflows/ci-workflows-runners.yaml
+++ b/.github/workflows/ci-workflows-runners.yaml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
+            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
@@ -36,7 +36,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
+            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Gazelle
@@ -46,7 +46,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
+            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Format
@@ -56,7 +56,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
+            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Buildifier
@@ -66,7 +66,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
+            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Lint
@@ -80,7 +80,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
+            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Delivery

--- a/.github/workflows/rbe-showcase.yaml
+++ b/.github/workflows/rbe-showcase.yaml
@@ -68,7 +68,7 @@ jobs:
       EXTRA: ${{ inputs.extra_bazel_flags }}
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
+      - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
 

--- a/.github/workflows/warming.yaml
+++ b/.github/workflows/warming.yaml
@@ -16,7 +16,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@8e5e3d1e7e9754e703f1b9cb79f491c06c00338f # v2026.26.2
+            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
             # we still need a .aspect/workflows/config.yaml until the AXL warming task is ready
             - name: Create legacy workflows config
               run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 include:
-  - component: $CI_SERVER_FQDN/aspect-build/setup-aspect-gitlab-component/setup@2026.26.1
+  - component: $CI_SERVER_FQDN/aspect-build/setup-aspect-gitlab-component/setup@2026.26.4
 
 workflow:
   rules:


### PR DESCRIPTION
Bumps each CI provider's `setup-aspect` integration to the latest release:

| Provider | From | To |
|---|---|---|
| GitHub Action | v2026.26.2 | **v2026.26.5** |
| Buildkite plugin | v2026.26.1 | **v2026.26.4** |
| CircleCI orb | 2026.26.3 | **2026.26.6** |
| GitLab component | 2026.26.1 | **2026.26.4** |

These releases set **v2026.26.37** as the minimum Aspect CLI version for `aspect ci bazelrc`, fix the "ci command" wording to name the exact command, and drop the cross-step `*_DEPRECATED` env-var signal (now a plain warning).

## Changes are visible to end-users

No — this only updates the example repo's own CI pinning.

## Test plan

- The bumped CI runs (GitHub Actions, Buildkite, CircleCI, GitLab) exercise each updated plugin on this PR.
