### PR TITLE
ci: bump setup-aspect plugins to latest releases and migrate warming to aspect ci warming

### DIFF
--- a/.buildkite/buildkite.yaml
+++ b/.buildkite/buildkite.yaml
@@ -4,7 +4,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#34570cb8821b4d8d3549752b0bae70027cfc882b: ~ # v2026.26.4
+    - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
   retry:
     manual:
       allowed: true
@@ -23,7 +23,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#34570cb8821b4d8d3549752b0bae70027cfc882b: ~ # v2026.26.4
+    - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
   retry:
     manual:
       allowed: true
@@ -42,7 +42,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#34570cb8821b4d8d3549752b0bae70027cfc882b: ~ # v2026.26.4
+    - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
   retry:
     manual:
       allowed: true
@@ -61,7 +61,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#34570cb8821b4d8d3549752b0bae70027cfc882b: ~ # v2026.26.4
+    - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
   retry:
     manual:
       allowed: true
@@ -80,7 +80,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#34570cb8821b4d8d3549752b0bae70027cfc882b: ~ # v2026.26.4
+    - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
   retry:
     manual:
       allowed: true
@@ -99,7 +99,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#34570cb8821b4d8d3549752b0bae70027cfc882b: ~ # v2026.26.4
+    - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
   retry:
     manual:
       allowed: true

--- a/.buildkite/buildkite.yaml
+++ b/.buildkite/buildkite.yaml
@@ -4,7 +4,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+    - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
   retry:
     manual:
       allowed: true
@@ -23,7 +23,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+    - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
   retry:
     manual:
       allowed: true
@@ -42,7 +42,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+    - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
   retry:
     manual:
       allowed: true
@@ -61,7 +61,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+    - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
   retry:
     manual:
       allowed: true
@@ -80,7 +80,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+    - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
   retry:
     manual:
       allowed: true
@@ -99,7 +99,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#63f7af7bde5d378934d54edf0978edc02791375a: ~ # v2026.26.5
+    - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
   retry:
     manual:
       allowed: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  setup-aspect: aspect-build/setup-aspect@2026.26.6
+  setup-aspect: aspect-build/setup-aspect@2026.26.7
 
 workflows:
   aspect-workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,31 +98,13 @@ jobs:
           name: Delivery
           command: aspect delivery --task:name=delivery-cci
 
-  # TODO: migrate warming to AXL warming task once available
   warming:
-    environment:
-      ASPECT_WORKFLOWS_CIRCLE_PIPELINE_NUMBER: << pipeline.number >>
-      ASPECT_WORKFLOWS_CIRCLE_PIPELINE_PROJECT_TYPE: << pipeline.project.type >>
-      ASPECT_WORKFLOWS_CIRCLE_WORKFLOW_BASE_NAME: aspect-workflows
-      ASPECT_WORKFLOWS_CONFIG: .aspect/workflows/config.yaml
     machine: true
     resource_class: aspect-build/aspect-default
     working_directory: /mnt/ephemeral/workdir
     steps:
       - checkout
       - setup-aspect/setup
-      # we still need a .aspect/workflows/config.yaml until the AXL warming task is ready
       - run:
-          name: Create legacy workflows config
-          command: |
-            mkdir -p .aspect/workflows
-            cat > .aspect/workflows/config.yaml << 'EOF'
-            tasks:
-              - warming:
-            EOF
-      - run:
-          name: Create warming archive for root
-          command: rosetta run warming
-      - run:
-          name: Archive warming tars
-          command: /etc/aspect/workflows/bin/warming_archive
+          name: Warming
+          command: aspect ci warming --task:name warming -- //...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  setup-aspect: aspect-build/setup-aspect@2026.26.7
+  setup-aspect: aspect-build/setup-aspect@2026.26.8
 
 workflows:
   aspect-workflows:

--- a/.github/workflows/ci-github-runners.yaml
+++ b/.github/workflows/ci-github-runners.yaml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
@@ -36,7 +36,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Gazelle
@@ -46,7 +46,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Format
@@ -56,7 +56,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Buildifier
@@ -66,7 +66,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Lint
@@ -80,7 +80,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Delivery

--- a/.github/workflows/ci-github-runners.yaml
+++ b/.github/workflows/ci-github-runners.yaml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
@@ -36,7 +36,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Gazelle
@@ -46,7 +46,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Format
@@ -56,7 +56,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Buildifier
@@ -66,7 +66,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Lint
@@ -80,7 +80,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Delivery

--- a/.github/workflows/ci-workflows-runners.yaml
+++ b/.github/workflows/ci-workflows-runners.yaml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
@@ -36,7 +36,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Gazelle
@@ -46,7 +46,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Format
@@ -56,7 +56,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Buildifier
@@ -66,7 +66,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Lint
@@ -80,7 +80,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Delivery

--- a/.github/workflows/ci-workflows-runners.yaml
+++ b/.github/workflows/ci-workflows-runners.yaml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
@@ -36,7 +36,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Gazelle
@@ -46,7 +46,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Format
@@ -56,7 +56,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Buildifier
@@ -66,7 +66,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Lint
@@ -80,7 +80,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Delivery

--- a/.github/workflows/rbe-showcase.yaml
+++ b/.github/workflows/rbe-showcase.yaml
@@ -68,7 +68,7 @@ jobs:
       EXTRA: ${{ inputs.extra_bazel_flags }}
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
 

--- a/.github/workflows/rbe-showcase.yaml
+++ b/.github/workflows/rbe-showcase.yaml
@@ -68,7 +68,7 @@ jobs:
       EXTRA: ${{ inputs.extra_bazel_flags }}
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+      - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
 

--- a/.github/workflows/warming.yaml
+++ b/.github/workflows/warming.yaml
@@ -9,7 +9,6 @@ on:
     # Allow this to be triggered manually via the GitHub UI Actions tab
     workflow_dispatch:
 
-# TODO: migrate warming to AXL warming task once available
 jobs:
     warming-archive:
         name: Aspect Workflows Warming
@@ -17,15 +16,5 @@ jobs:
         steps:
             - uses: actions/checkout@v6
             - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
-            # we still need a .aspect/workflows/config.yaml until the AXL warming task is ready
-            - name: Create legacy workflows config
-              run: |
-                mkdir -p .aspect/workflows
-                cat > .aspect/workflows/config.yaml << 'EOF'
-                tasks:
-                  - warming:
-                EOF
-            - name: Create warming archive
-              run: rosetta run warming
-            - name: Archive warming tars
-              run: /etc/aspect/workflows/bin/warming_archive
+            - name: Warming
+              run: aspect ci warming --task:name warming -- //...

--- a/.github/workflows/warming.yaml
+++ b/.github/workflows/warming.yaml
@@ -16,7 +16,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@7d93c420bbaa64d7ee6057770b8d0d4a3307c76a # v2026.26.5
+            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
             # we still need a .aspect/workflows/config.yaml until the AXL warming task is ready
             - name: Create legacy workflows config
               run: |

--- a/.github/workflows/warming.yaml
+++ b/.github/workflows/warming.yaml
@@ -16,7 +16,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@80c3f7a84ad9b0c10c31bdd86128f83b0ecdf61e # v2026.26.6
+            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
             # we still need a .aspect/workflows/config.yaml until the AXL warming task is ready
             - name: Create legacy workflows config
               run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 include:
-  - component: $CI_SERVER_FQDN/aspect-build/setup-aspect-gitlab-component/setup@2026.26.5
+  - component: $CI_SERVER_FQDN/aspect-build/setup-aspect-gitlab-component/setup@2026.26.6
 
 workflow:
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 include:
-  - component: $CI_SERVER_FQDN/aspect-build/setup-aspect-gitlab-component/setup@2026.26.4
+  - component: $CI_SERVER_FQDN/aspect-build/setup-aspect-gitlab-component/setup@2026.26.5
 
 workflow:
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,7 +80,6 @@ delivery:
   script:
     - aspect delivery --task:name=delivery-gl
 
-# TODO: migrate warming to AXL warming task once available
 warming:
   tags:
     - aspect-workflows
@@ -90,14 +89,4 @@ warming:
       - if: '$CI_PIPELINE_SOURCE == "schedule"'
   extends: .setup-aspect
   script:
-    # we still need a .aspect/workflows/config.yaml until the AXL warming task is ready
-    - /etc/aspect/workflows/bin/gitlab_section_start "legacy_config" "Create legacy workflows config"
-    - mkdir -p .aspect/workflows
-    - printf 'tasks:\n  - warming:\n' > .aspect/workflows/config.yaml
-    - /etc/aspect/workflows/bin/gitlab_section_end "legacy_config"
-    - /etc/aspect/workflows/bin/gitlab_section_start "warming" "Warming"
-    - rosetta run warming
-    - /etc/aspect/workflows/bin/gitlab_section_end "warming"
-    - /etc/aspect/workflows/bin/gitlab_section_start "archive_warming_tars" "Archive warming tars"
-    - /etc/aspect/workflows/bin/warming_archive
-    - /etc/aspect/workflows/bin/gitlab_section_end "archive_warming_tars"
+    - aspect ci warming --task:name warming -- //...


### PR DESCRIPTION
Bumps each CI provider's `setup-aspect` integration to the latest release, and migrates the warming jobs to the new `aspect ci warming` task.

## Plugin bumps

| Provider | To |
|---|---|
| GitHub Action | **v2026.26.7** (`b7443e6`) |
| Buildkite plugin | **v2026.26.6** (`3f1113f`) |
| CircleCI orb | **2026.26.8** |
| GitLab component | **2026.26.6** |

These releases set **v2026.26.38** as the minimum Aspect CLI version for the `aspect ci` tasks, and redact header-flag values (e.g. `--remote_header=x-identity=…`) in the echoed bazelrc.

## Warming migration

Replace the legacy two-step warming (`rosetta run warming` + `/etc/aspect/workflows/bin/warming_archive`, plus the throwaway `.aspect/workflows/config.yaml`) with a single `aspect ci warming -- //...` across the GitHub Actions, GitLab, and CircleCI warming jobs. Drops the now-resolved "migrate to AXL warming" TODOs and the legacy-config scaffolding.

## Changes are visible to end-users

No — only updates the example repo's own CI pinning and warming jobs.

## Test plan

- All CI configs parse.
- The bumped CI runs across all four providers exercise the updated plugins, and the scheduled warming jobs exercise `aspect ci warming`.
