### PR TITLE
ci: bump setup-aspect plugins to latest releases

### DIFF
--- a/.buildkite/buildkite.yaml
+++ b/.buildkite/buildkite.yaml
@@ -4,7 +4,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
+    - aspect-build/setup-aspect#cd744c11dc472c2f24c8bc775e844eccaa82428b: ~ # v2026.26.7
   retry:
     manual:
       allowed: true
@@ -23,7 +23,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
+    - aspect-build/setup-aspect#cd744c11dc472c2f24c8bc775e844eccaa82428b: ~ # v2026.26.7
   retry:
     manual:
       allowed: true
@@ -42,7 +42,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
+    - aspect-build/setup-aspect#cd744c11dc472c2f24c8bc775e844eccaa82428b: ~ # v2026.26.7
   retry:
     manual:
       allowed: true
@@ -61,7 +61,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
+    - aspect-build/setup-aspect#cd744c11dc472c2f24c8bc775e844eccaa82428b: ~ # v2026.26.7
   retry:
     manual:
       allowed: true
@@ -80,7 +80,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
+    - aspect-build/setup-aspect#cd744c11dc472c2f24c8bc775e844eccaa82428b: ~ # v2026.26.7
   retry:
     manual:
       allowed: true
@@ -99,7 +99,7 @@ steps:
   agents:
     queue: aspect-default
   plugins:
-    - aspect-build/setup-aspect#3f1113f5a140f660970bcfae4a8c0585d1e1dd0c: ~ # v2026.26.6
+    - aspect-build/setup-aspect#cd744c11dc472c2f24c8bc775e844eccaa82428b: ~ # v2026.26.7
   retry:
     manual:
       allowed: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  setup-aspect: aspect-build/setup-aspect@2026.26.8
+  setup-aspect: aspect-build/setup-aspect@2026.26.9
 
 workflows:
   aspect-workflows:

--- a/.github/workflows/ci-github-runners.yaml
+++ b/.github/workflows/ci-github-runners.yaml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+            - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
@@ -36,7 +36,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+            - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Gazelle
@@ -46,7 +46,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+            - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Format
@@ -56,7 +56,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+            - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Buildifier
@@ -66,7 +66,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+            - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Lint
@@ -80,7 +80,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+            - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Delivery

--- a/.github/workflows/ci-workflows-runners.yaml
+++ b/.github/workflows/ci-workflows-runners.yaml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+            - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Test
@@ -36,7 +36,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+            - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Gazelle
@@ -46,7 +46,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+            - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Format
@@ -56,7 +56,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+            - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Buildifier
@@ -66,7 +66,7 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+            - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Lint
@@ -80,7 +80,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0 # tags required for workspace status command
-            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+            - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
               with:
                 aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
             - name: Delivery

--- a/.github/workflows/rbe-showcase.yaml
+++ b/.github/workflows/rbe-showcase.yaml
@@ -68,7 +68,7 @@ jobs:
       EXTRA: ${{ inputs.extra_bazel_flags }}
     steps:
       - uses: actions/checkout@v6
-      - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+      - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
         with:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
 

--- a/.github/workflows/warming.yaml
+++ b/.github/workflows/warming.yaml
@@ -15,6 +15,6 @@ jobs:
         runs-on: [self-hosted, aspect-workflows, aspect-default]
         steps:
             - uses: actions/checkout@v6
-            - uses: aspect-build/setup-aspect@b7443e6f0b4a72507d73fcc49c16eecaf28786f9 # v2026.26.7
+            - uses: aspect-build/setup-aspect@8689a6ee13d15bbde12e55632330595076ecabf9 # v2026.26.8
             - name: Warming
               run: aspect ci warming --task:name warming -- //...

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 include:
-  - component: $CI_SERVER_FQDN/aspect-build/setup-aspect-gitlab-component/setup@2026.26.6
+  - component: $CI_SERVER_FQDN/aspect-build/setup-aspect-gitlab-component/setup@2026.26.7
 
 workflow:
   rules:


### PR DESCRIPTION
Bumps each CI provider's `setup-aspect` integration to the latest release:

| Provider | To |
|---|---|
| GitHub Action | **v2026.26.8** (`8689a6e`) |
| Buildkite plugin | **v2026.26.7** (`cd744c1`) |
| CircleCI orb | **2026.26.9** |
| GitLab component | **2026.26.7** |

## Changes are visible to end-users

No — only updates the example repo's own CI pinning.

## Test plan

- The bumped CI runs across all four providers exercise the updated plugins on this PR.
