### PR TITLE
chore: add calculator demo with red-to-green test

### DIFF
--- a/calculator/BUILD.bazel
+++ b/calculator/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "calculator_lib",
+    srcs = ["calculator.go"],
+    importpath = "github.com/aspect-build/bazel-examples/calculator",
+    visibility = ["//visibility:private"],
+)
+
+go_test(
+    name = "calculator_test",
+    size = "small",
+    srcs = ["calculator_test.go"],
+    embed = [":calculator_lib"],
+)
+
+go_binary(
+    name = "calculator",
+    embed = [":calculator_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/calculator/calculator.go
+++ b/calculator/calculator.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Add returns the sum of two integers.
 func Add(a, b int) int {
-	return a + b
+	return a - b
 }
 
 func main() {

--- a/calculator/calculator.go
+++ b/calculator/calculator.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+// Add returns the sum of two integers.
+func Add(a, b int) int {
+	return a - b
+}
+
+func main() {
+	fmt.Println("2 + 2 =", Add(2, 2))
+}

--- a/calculator/calculator.go
+++ b/calculator/calculator.go
@@ -7,6 +7,7 @@ func Add(a, b int) int {
 	return a - b
 }
 
+
 func main() {
 	fmt.Println("2 + 2 =", Add(2, 2))
 }

--- a/calculator/calculator.go
+++ b/calculator/calculator.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Add returns the sum of two integers.
 func Add(a, b int) int {
-	return a - b
+	return a + b
 }
 
 func main() {

--- a/calculator/calculator_test.go
+++ b/calculator/calculator_test.go
@@ -1,0 +1,11 @@
+package main
+
+import "testing"
+
+func TestAdd(t *testing.T) {
+	got := Add(2, 2)
+	want := 4
+	if got != want {
+		t.Errorf("Add(2, 2) = %d; want %d", got, want)
+	}
+}


### PR DESCRIPTION
Adds a small self-contained Go example under `calculator/` for demos: a trivial `Add()` function plus `//calculator:calculator_test`. The history walks a red-to-green flow — the first commit ships `Add()` intentionally buggy (`a - b`) so the test fails, and the second commit applies the one-line fix (`a + b`) so it passes.

Useful for live demos of `bazel test` failing then a minimal fix turning it green. To reproduce the red state locally, check out the first commit or flip line 7 of `calculator/calculator.go` back to `a - b`.

## Changes are visible to end-users

No — adds a new example directory to this examples repo; no existing behavior changes.

## Test plan

- `bazel test //calculator:calculator_test` passes at HEAD (green fix commit).
- Checking out the first commit (`Add calculator demo with failing test`) and running the same target reproduces the failing state.
