### PR TITLE
docs: show how to customize Aspect's CI status surfaces

### DIFF
--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -2,6 +2,9 @@
 
 load("@aspect//feature/artifacts.axl", "ArtifactUpload")
 load("@aspect//feature/buildkite_annotations.axl", "BuildkiteAnnotations")
+load("@aspect//feature/github_status_checks.axl", "GithubStatusChecks")
+load("@aspect//feature/github_status_comments.axl", "DEFAULT_BODY_TEMPLATE", "GithubStatusComments")
+load("@aspect//feature/gitlab_status_comments.axl", "GitlabStatusComments")
 load("@aspect//format.axl", "format")
 load("@aspect//private/lib/bazel_results.axl", "SUMMARY_TEMPLATE")
 load("@aspect//private/lib/lint_results.axl", LINT_DETAILS_TEMPLATE = "DETAILS_TEMPLATE")
@@ -82,6 +85,35 @@ _LINT_DETAILS_HEADER = """> :books: House lint rules: https://github.com/aspect-
 
 _CUSTOM_LINT_DETAILS_TEMPLATE = _LINT_DETAILS_HEADER + LINT_DETAILS_TEMPLATE
 
+# PR / MR summary comment customization.
+#
+# `GithubStatusComments` aggregates every sibling CI job's task status into one
+# PR comment. `GitlabStatusComments` renders the same body into a GitLab MR
+# note and reuses GitHub's exported default, so one patched template serves
+# both. Unlike the check-run surfaces this takes a single "body" key — the
+# comment is one document covering all tasks, not per-kind renders.
+#
+# Same patch-plus-drift-guard shape as above: swap the built-in heading for a
+# repo-specific one and leave the rest of the body (task sections, failure
+# snippets, repro/fix commands, tips, footer) untouched.
+_DEFAULT_COMMENT_HEADING = """## ✨ Aspect Workflows Tasks"""
+
+_CUSTOM_COMMENT_HEADING = """## ✨ Bazel Examples CI"""
+
+if _DEFAULT_COMMENT_HEADING not in DEFAULT_BODY_TEMPLATE:
+    fail("Aspect DEFAULT_BODY_TEMPLATE drifted; update _DEFAULT_COMMENT_HEADING.")
+
+_CUSTOM_COMMENT_BODY_TEMPLATE = DEFAULT_BODY_TEMPLATE.replace(
+    _DEFAULT_COMMENT_HEADING,
+    _CUSTOM_COMMENT_HEADING,
+)
+
+# GitHub status check summary customization.
+#
+# The check-run summary uses the same shared `SUMMARY_TEMPLATE` as the Buildkite
+# annotation, so the patched version above serves both surfaces — the same
+# status line shows up in the Checks tab and in the annotation.
+
 def _drop_vanilla_bazel_except_build_and_test(ctx: TaskContext, info: ReproFixInfo) -> ReproFixSuggestion:
     if not info.slug.endswith("-vanilla-bazel") or info.task_kind == "build" or info.task_kind == "test":
         return REPRO_FIX_ACCEPT
@@ -152,6 +184,31 @@ def config(ctx: ConfigContext):
     # Open the build + test phase log sections so a failing annotation lands
     # next to the log output that explains it.
     ctx.features[BuildkiteAnnotations].args.expand_phases = ["build", "test"]
+
+    # PR / MR summary comment: one patched body serves both hosts, since
+    # GitlabStatusComments renders GitHub's exported default template.
+    ctx.features[GithubStatusComments].args.templates = {
+        "body": _CUSTOM_COMMENT_BODY_TEMPLATE,
+    }
+    ctx.features[GitlabStatusComments].args.templates = {
+        "body": _CUSTOM_COMMENT_BODY_TEMPLATE,
+    }
+
+    # Swap the row badges for plain-text labels. Keyed by badge_key, which AXL
+    # precomputes from severity + status, not by raw lifecycle status.
+    ctx.features[GithubStatusComments].args.status_badges = {
+        "passed": "✅ ok",
+        "failed": "❌ broke",
+        "warning": "⚠️ check",
+    }
+
+    # GitHub status checks share the renderer table with the Buildkite
+    # annotations, so the same "summary"/"details" keys apply — here reusing
+    # both patched templates so the Checks tab and the annotation agree.
+    ctx.features[GithubStatusChecks].args.templates = {
+        "summary": _CUSTOM_SUMMARY_TEMPLATE,
+        "lint": {"details": _CUSTOM_LINT_DETAILS_TEMPLATE},
+    }
 
     # Customize repro/fix suggestions
     lifecycle = ctx.traits[TaskLifecycleTrait]

--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -1,7 +1,10 @@
 """Aspect CLI configuration."""
 
 load("@aspect//feature/artifacts.axl", "ArtifactUpload")
+load("@aspect//feature/buildkite_annotations.axl", "BuildkiteAnnotations")
 load("@aspect//format.axl", "format")
+load("@aspect//private/lib/bazel_results.axl", "SUMMARY_TEMPLATE")
+load("@aspect//private/lib/lint_results.axl", LINT_DETAILS_TEMPLATE = "DETAILS_TEMPLATE")
 load("@aspect//traits.axl", "BazelTrait", "REPRO_FIX_ACCEPT", "REPRO_FIX_REJECT", "ReproFixInfo", "ReproFixSuggestion", "TaskLifecycleTrait")
 
 buildifier = format.alias(
@@ -40,6 +43,44 @@ buildifier = format.alias(
     },
     summary = "Format Starlark files using buildifier.",
 )
+
+# Buildkite annotation customization.
+#
+# `BuildkiteAnnotations` renders each task's annotation through the same
+# per-kind renderers as `GithubStatusChecks`, so `args.templates` takes
+# "summary" / "details" Jinja2 overrides. Rather than re-author a template
+# (and lose the invocation rows, target counts, cache rate, artifact links
+# and tips block), we import the built-in and patch just what we want.
+#
+# The `fail()` is a drift guard: `.replace()` against a template that no
+# longer contains the anchor is a silent no-op, so an Aspect CLI upgrade that
+# edits the built-in would quietly revert this customization with nothing in
+# the logs. Failing at config-load time surfaces it instead.
+
+# Swap the built-in's trailing "Last update" line for a Buildkite-native
+# status line carrying a branch chip. Applies to every task kind, since the
+# summary template is shared across all of them.
+_DEFAULT_LAST_UPDATE_LINE = """:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}"""
+
+_CUSTOM_LAST_UPDATE_LINE = """:buildkite: **Status:** `{{ last_update }}`{% if branch %} · :git: `{{ branch }}`{% endif %}{% endif %}"""
+
+if _DEFAULT_LAST_UPDATE_LINE not in SUMMARY_TEMPLATE:
+    fail("Aspect SUMMARY_TEMPLATE drifted; update _DEFAULT_LAST_UPDATE_LINE.")
+
+_CUSTOM_SUMMARY_TEMPLATE = SUMMARY_TEMPLATE.replace(
+    _DEFAULT_LAST_UPDATE_LINE,
+    _CUSTOM_LAST_UPDATE_LINE,
+)
+
+# Prepend a lint-specific callout to the details body. Scoped under "lint" so
+# it applies to the lint annotation only — details templates are per-kind, so
+# an unscoped override would replace the build, test, format and gazelle
+# bodies with lint's.
+_LINT_DETAILS_HEADER = """> :books: House lint rules: https://github.com/aspect-build/bazel-examples/tree/main/tools/lint
+
+"""
+
+_CUSTOM_LINT_DETAILS_TEMPLATE = _LINT_DETAILS_HEADER + LINT_DETAILS_TEMPLATE
 
 def _drop_vanilla_bazel_except_build_and_test(ctx: TaskContext, info: ReproFixInfo) -> ReproFixSuggestion:
     if not info.slug.endswith("-vanilla-bazel") or info.task_kind == "build" or info.task_kind == "test":
@@ -99,6 +140,18 @@ def config(ctx: ConfigContext):
     ctx.features[ArtifactUpload].args.upload_test_logs = "failed"
     ctx.features[ArtifactUpload].args.upload_profile = True
     ctx.features[ArtifactUpload].args.upload_bep = True
+
+    # Customize the Buildkite annotations (see the templates above). Flat
+    # "summary"/"details" keys apply to every task kind; nesting under a task
+    # kind scopes an override to that kind alone.
+    ctx.features[BuildkiteAnnotations].args.templates = {
+        "summary": _CUSTOM_SUMMARY_TEMPLATE,
+        "lint": {"details": _CUSTOM_LINT_DETAILS_TEMPLATE},
+    }
+
+    # Open the build + test phase log sections so a failing annotation lands
+    # next to the log output that explains it.
+    ctx.features[BuildkiteAnnotations].args.expand_phases = ["build", "test"]
 
     # Customize repro/fix suggestions
     lifecycle = ctx.traits[TaskLifecycleTrait]

--- a/.aspect/config.axl
+++ b/.aspect/config.axl
@@ -108,11 +108,27 @@ _CUSTOM_COMMENT_BODY_TEMPLATE = DEFAULT_BODY_TEMPLATE.replace(
     _CUSTOM_COMMENT_HEADING,
 )
 
-# GitHub status check summary customization.
+# Title customization.
 #
-# The check-run summary uses the same shared `SUMMARY_TEMPLATE` as the Buildkite
-# annotation, so the patched version above serves both surfaces — the same
-# status line shows up in the Checks tab and in the annotation.
+# The title is the single line reviewers scan — the check-run title in the
+# Checks tab, and the heading of a Buildkite annotation. It renders from
+# `icon`, `task_kind`, `subject`, `state` and `status`.
+#
+# `state` is the verdict the renderer already computed ("Passed", "3 errors,
+# 8 warnings", "Running...", "12 delivered"), so reordering or rewording the
+# title doesn't mean reimplementing the per-kind status logic. Here we swap the
+# built-in's `·` separator for an em dash and read "on <subject>".
+#
+# No drift guard needed: these are whole templates rather than patches, so
+# there's no anchor that could silently stop matching. A title that fails to
+# render — or renders blank, which a valid template can do when every variable
+# it references is empty — falls back to the built-in layout and logs a warning.
+_CUSTOM_TITLE_TEMPLATE = """{{ icon }} {{ task_kind }}{% if subject %} on {{ subject }}{% endif %}{% if state %} — {{ state }}{% endif %}"""
+
+# Scoped under "lint" so only the lint surfaces get it; every other kind keeps
+# the shared title above. Drops the subject, which for lint is just `//...`,
+# in favour of naming where the rules live.
+_CUSTOM_LINT_TITLE_TEMPLATE = """{{ icon }} lint (tools/lint){% if state %} — {{ state }}{% endif %}"""
 
 def _drop_vanilla_bazel_except_build_and_test(ctx: TaskContext, info: ReproFixInfo) -> ReproFixSuggestion:
     if not info.slug.endswith("-vanilla-bazel") or info.task_kind == "build" or info.task_kind == "test":
@@ -174,11 +190,17 @@ def config(ctx: ConfigContext):
     ctx.features[ArtifactUpload].args.upload_bep = True
 
     # Customize the Buildkite annotations (see the templates above). Flat
-    # "summary"/"details" keys apply to every task kind; nesting under a task
-    # kind scopes an override to that kind alone.
+    # "title"/"summary"/"details" keys apply to every task kind; nesting under a
+    # task kind scopes an override to that kind alone, and overlays the flat
+    # keys rather than replacing them — so lint keeps the shared summary while
+    # taking its own title and details.
     ctx.features[BuildkiteAnnotations].args.templates = {
+        "title": _CUSTOM_TITLE_TEMPLATE,
         "summary": _CUSTOM_SUMMARY_TEMPLATE,
-        "lint": {"details": _CUSTOM_LINT_DETAILS_TEMPLATE},
+        "lint": {
+            "title": _CUSTOM_LINT_TITLE_TEMPLATE,
+            "details": _CUSTOM_LINT_DETAILS_TEMPLATE,
+        },
     }
 
     # Open the build + test phase log sections so a failing annotation lands
@@ -203,11 +225,15 @@ def config(ctx: ConfigContext):
     }
 
     # GitHub status checks share the renderer table with the Buildkite
-    # annotations, so the same "summary"/"details" keys apply — here reusing
-    # both patched templates so the Checks tab and the annotation agree.
+    # annotations, so the same "title"/"summary"/"details" keys apply — here
+    # reusing every template so the Checks tab and the annotation agree.
     ctx.features[GithubStatusChecks].args.templates = {
+        "title": _CUSTOM_TITLE_TEMPLATE,
         "summary": _CUSTOM_SUMMARY_TEMPLATE,
-        "lint": {"details": _CUSTOM_LINT_DETAILS_TEMPLATE},
+        "lint": {
+            "title": _CUSTOM_LINT_TITLE_TEMPLATE,
+            "details": _CUSTOM_LINT_DETAILS_TEMPLATE,
+        },
     }
 
     # Customize repro/fix suggestions


### PR DESCRIPTION
CI in this repo runs six task kinds across GitHub Actions and Buildkite, which makes it a good place to demonstrate customizing Aspect's status surfaces. Customers have been asking how, so this config now shows all four in one place.

**Buildkite annotations** and **GitHub status checks** share the same per-kind renderer table, so they take the same `summary` / `details` Jinja2 keys — and the same patched template serves both. Rather than replace a template wholesale (losing the invocation rows, target counts, cache rate, artifact links and tips block), the example imports the built-in and patches one line:

```python
_DEFAULT_LAST_UPDATE_LINE = """:speech_balloon: **Last update:** `{{ last_update }}`{% endif %}"""
_CUSTOM_LAST_UPDATE_LINE = """:buildkite: **Status:** `{{ last_update }}`{% if branch %} · :git: `{{ branch }}`{% endif %}{% endif %}"""

if _DEFAULT_LAST_UPDATE_LINE not in SUMMARY_TEMPLATE:
    fail("Aspect SUMMARY_TEMPLATE drifted; update _DEFAULT_LAST_UPDATE_LINE.")
```

Each patch is guarded by a `fail()`. `.replace()` against a template that no longer contains the anchor is a silent no-op, so a CLI upgrade that edits a built-in would quietly revert the customization with nothing in the logs. These templates live under `private/lib/` and are not stability-guaranteed, which is exactly the risk the guard catches.

**Per-kind scoping** is shown with a lint-specific callout nested under `"lint"`. The summary template is shared across kinds so a summary patch applies everywhere; details templates are per-kind, so an unscoped `"details"` override would replace the build, test, format and gazelle bodies with lint's.

**Titles** are customized too, since that's the line reviewers actually scan. A shared template reads `<icon> <kind> on <subject> — <state>`, and a lint-scoped one drops the subject (just `//...` for lint) in favour of naming where the rules live. `state` carries the verdict Aspect already computed, so rewording the title doesn't mean reimplementing per-kind status logic. These need no drift guard — they're whole templates rather than patches, so no anchor can silently stop matching.

This also shows that a per-kind block **overlays** the flat keys rather than replacing them: lint keeps the shared summary while taking its own title and details.

**PR / MR summary comments** work differently: `GithubStatusComments` takes a single `body` key, because the comment is one document covering every task rather than a per-kind render. `GitlabStatusComments` reuses GitHub's exported default template, so one patched body serves both hosts. The example also shows `status_badges`, which swaps the row emoji without touching a template at all — it merges over the defaults, so unlisted keys keep their built-ins.

Requires Aspect CLI 2026.33.2, which this repo already pins.

---

### Changes are visible to end-users: no

### Test plan

- Manual testing. To reproduce:
  - `aspect format --help` from the repo root — loads `.aspect/config.axl` and exits 0, confirming every template resolves against the pinned CLI.
  - `aspect buildifier .aspect/config.axl` — passes, no reformatting.
  - Verified both drift guards fire: editing either anchor constant fails config load with the naming message and exit 1 (`Aspect SUMMARY_TEMPLATE drifted…` / `Aspect DEFAULT_BODY_TEMPLATE drifted…`).
  - Verified the patches do what they claim rather than just loading: the comment heading is replaced, the old heading is gone, and the footer plus task-section macros survive; `status_badges` merges over the defaults so `running` and `aborted` keep their built-in emoji.
  - Rendered the annotation bodies through the CLI's own per-kind renderers with this exact template config: the custom status line appears in all 15 summary-bearing scenarios, and the lint callout in exactly the 4 lint scenarios — not in build, test, format, gazelle or delivery, confirming the scoping.
  - The annotations and comments themselves only render on their respective hosts (each feature is env-gated and skips silently elsewhere), so the checks on this PR validate that the config loads and formats rather than exercising the rendered surfaces.
  - Rendered titles per kind through `compose_title` on the released 2026.33.2: `build`, `test` and `format` take the shared title (`✅ build on //... — Successful build`) while `lint` takes its scoped one (`⚠️ lint (tools/lint) — 3 errors, 8 warnings`), confirming the scoping.
  - Verified the title safety net on the release: a broken template and one that renders blank both fall back to the built-in layout rather than emitting an empty title.
